### PR TITLE
Shadow activity to handle activity results

### DIFF
--- a/cashier-sample/src/main/java/com/getkeepsafe/cashier/sample/MainActivity.java
+++ b/cashier-sample/src/main/java/com/getkeepsafe/cashier/sample/MainActivity.java
@@ -302,13 +302,6 @@ public class MainActivity extends AppCompatActivity {
         cashier.dispose();
     }
 
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (!cashier.onActivityResult(requestCode, resultCode, data)) {
-            super.onActivityResult(requestCode, resultCode, data);
-        }
-    }
-
     private void initCashier() {
         if (cashier != null) {
             cashier.dispose();

--- a/cashier/src/main/AndroidManifest.xml
+++ b/cashier/src/main/AndroidManifest.xml
@@ -1,1 +1,11 @@
-<manifest package="com.getkeepsafe.cashier"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.getkeepsafe.cashier">
+
+    <application>
+        <activity
+            android:name="com.getkeepsafe.cashier.ShadowActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Transparent" />
+    </application>
+</manifest>

--- a/cashier/src/main/java/com/getkeepsafe/cashier/Action.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/Action.java
@@ -1,0 +1,5 @@
+package com.getkeepsafe.cashier;
+
+public interface Action<T> {
+    void run(T obj);
+}

--- a/cashier/src/main/java/com/getkeepsafe/cashier/Cashier.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/Cashier.java
@@ -176,7 +176,15 @@ public class Cashier {
         }
 
         final String payload = developerPayload == null ? "" : developerPayload;
-        vendor.purchase(activity, product, payload, listener);
+
+        ShadowActivity.action = new Action<Activity>() {
+          @Override
+          public void run(Activity activity) {
+            vendor.purchase(activity, product, payload, listener);
+          }
+        };
+        ShadowActivity.cashier = Cashier.this;
+        activity.startActivity(new Intent(activity, ShadowActivity.class));
       }
 
       @Override

--- a/cashier/src/main/java/com/getkeepsafe/cashier/ShadowActivity.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/ShadowActivity.java
@@ -1,0 +1,39 @@
+package com.getkeepsafe.cashier;
+
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+public class ShadowActivity extends Activity {
+
+    @SuppressLint("StaticFieldLeak")
+    static Cashier cashier;
+    static Action<Activity> action;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (action != null && cashier != null) {
+            action.run(this);
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (cashier != null) {
+            cashier.onActivityResult(requestCode, resultCode, data);
+        }
+        finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        action = null;
+        cashier = null;
+    }
+}

--- a/cashier/src/main/res/values/styles.xml
+++ b/cashier/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Transparent" parent="android:Theme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>

--- a/cashier/src/test/java/com/getkeepsafe/cashier/CashierTest.java
+++ b/cashier/src/test/java/com/getkeepsafe/cashier/CashierTest.java
@@ -2,6 +2,7 @@ package com.getkeepsafe.cashier;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 
 import org.json.JSONException;
@@ -213,7 +214,7 @@ public class CashierTest {
     final String devPayload = "abc";
 
     cashier.purchase(activity, product, devPayload, listener);
-    verify(testVendor).purchase(activity, product, devPayload, listener);
+    verify(activity, times(1)).startActivity(new Intent(activity, ShadowActivity.class));
     verifyZeroInteractions(listener);
   }
 }

--- a/cashier/src/test/java/com/getkeepsafe/cashier/ShadowActivityTest.java
+++ b/cashier/src/test/java/com/getkeepsafe/cashier/ShadowActivityTest.java
@@ -1,0 +1,42 @@
+package com.getkeepsafe.cashier;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class ShadowActivityTest {
+
+    private final Cashier cashier = mock(Cashier.class);
+    private static final int REQUEST_CODE = 1;
+    private static final int RESULT_CODE = Activity.RESULT_OK;
+
+    @Test
+    public void passesActivityResultToCashierAndFinishes() {
+        ShadowActivity.action = new Action<Activity>() {
+            @Override
+            public void run(Activity activity) {
+                activity.startActivityForResult(new Intent(), REQUEST_CODE);
+            }
+        };
+        ShadowActivity.cashier = cashier;
+        ActivityController controller = Robolectric.buildActivity(ShadowActivity.class).create();
+        Activity activity = (Activity) controller.get();
+        org.robolectric.shadows.ShadowActivity shadowActivity = shadowOf(activity);
+        shadowActivity.receiveResult(new Intent(), Activity.RESULT_OK, null);
+        verify(cashier, times(1)).onActivityResult(REQUEST_CODE, RESULT_CODE, null);
+        assertTrue(shadowActivity.isFinishing());
+    }
+
+}


### PR DESCRIPTION
Closes #8 

Added `ShadowActivity`, that handles `onActivityResult` after purchase process is finished. This activity is constrained to portrait orientation only to decrease chances of activity recreation and thus disconnecting from original cashier instance.

Added `ShadowActivityTest`