### PR TITLE
Delegated getting SKU details to background thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ android:
   components:
   - platform-tools
   - tools
-  - build-tools-25.0.2
-  - android-25
+  - build-tools-27.0.3
+  - android-27
 
   - extra-google-m2repository
   - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,19 @@
 buildscript {
     repositories {
+        google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
 allprojects {
     repositories {
+        google()
+        mavenCentral()
         jcenter()
     }
 }

--- a/cashier-iab-debug-no-op/build.gradle
+++ b/cashier-iab-debug-no-op/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-  compile project(':cashier-iab')
+  api project(':cashier-iab')
 }

--- a/cashier-iab-debug/build.gradle
+++ b/cashier-iab-debug/build.gradle
@@ -26,15 +26,15 @@ android {
 }
 
 dependencies {
-  compile project(':cashier-iab')
+  api project(':cashier-iab')
 
-  provided deps.autoValue
-  provided deps.supportAnnotations
+  compileOnly deps.autoValue
+  compileOnly deps.supportAnnotations
   annotationProcessor deps.autoValue
   annotationProcessor deps.autoParcel
 
-  testCompile deps.robolectric
-  testCompile deps.junit
-  testCompile deps.mockito
-  testCompile deps.truth
+  testImplementation deps.robolectric
+  testImplementation deps.junit
+  testImplementation deps.mockito
+  testImplementation deps.truth
 }

--- a/cashier-iab/build.gradle
+++ b/cashier-iab/build.gradle
@@ -26,17 +26,17 @@ android {
 }
 
 dependencies {
-  compile project(':cashier')
+  api project(':cashier')
 
-  provided deps.autoValue
-  provided deps.supportAnnotations
+  compileOnly deps.autoValue
+  compileOnly deps.supportAnnotations
   annotationProcessor deps.autoValue
   annotationProcessor deps.autoParcel
 
-  testCompile deps.robolectric
-  testCompile deps.junit
-  testCompile deps.mockito
-  testCompile deps.truth
+  testImplementation deps.robolectric
+  testImplementation deps.junit
+  testImplementation deps.mockito
+  testImplementation deps.truth
 }
 
 apply from: rootProject.file('javadoc.gradle')

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -25,7 +25,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.RemoteException;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -302,7 +301,7 @@ public class InAppBillingV3Vendor implements Vendor {
     }
 
     @Override
-    public void getInventory(Context context, final Collection<String> inappSkus, final Collection<String> subSkus,
+    public void getInventory(Context context, final Collection<String> inAppSkus, final Collection<String> subSkus,
                              final InventoryListener listener) {
         if (context == null || listener == null) {
             throw new IllegalArgumentException("Context or listener is null");
@@ -314,7 +313,7 @@ public class InAppBillingV3Vendor implements Vendor {
             @Override
             public void run() {
                 // Convert the given collections to a list
-                final List<String> inappSkusList = inappSkus == null ? null : new ArrayList<>(inappSkus);
+                final List<String> inappSkusList = inAppSkus == null ? null : new ArrayList<>(inAppSkus);
                 final List<String> subSkusList = subSkus == null ? null : new ArrayList<>(subSkus);
 
                 final Inventory inventory = new Inventory();

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -632,7 +632,7 @@ public class InAppBillingV3Vendor implements Vendor {
     return -1;
   }
 
-  private Error purchaseError(int response) {
+  private Vendor.Error purchaseError(int response) {
     final int code;
     switch (response) {
       case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
@@ -658,7 +658,7 @@ public class InAppBillingV3Vendor implements Vendor {
     return new Vendor.Error(code, response);
   }
 
-  private Error consumeError(int response) {
+  private Vendor.Error consumeError(int response) {
     final int code;
     switch (response) {
       case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -356,7 +356,7 @@ public class InAppBillingV3Vendor implements Vendor {
           callThread.post(new Runnable() {
             @Override
             public void run() {
-             listener.failure(new Vendor.Error(INVENTORY_QUERY_UNAVAILABLE, -1));
+              listener.failure(new Vendor.Error(INVENTORY_QUERY_UNAVAILABLE, -1));
             }
           });
         }

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -22,8 +22,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.RemoteException;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -46,6 +48,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import static com.getkeepsafe.cashier.VendorConstants.CONSUME_CANCELED;
 import static com.getkeepsafe.cashier.VendorConstants.CONSUME_FAILURE;
@@ -82,586 +86,617 @@ import static com.getkeepsafe.cashier.iab.InAppBillingConstants.RESPONSE_INAPP_S
 import static com.getkeepsafe.cashier.iab.InAppBillingConstants.VENDOR_PACKAGE;
 
 public class InAppBillingV3Vendor implements Vendor {
-  private final AbstractInAppBillingV3API api;
-  private final String publicKey64;
 
-  private Logger logger;
-  private String developerPayload;
-  private Product pendingProduct;
-  private PurchaseListener purchaseListener;
-  private InitializationListener initializationListener;
+    @VisibleForTesting
+    static boolean DISABLE_EXECUTOR = false;
+    private final AbstractInAppBillingV3API api;
+    private final String publicKey64;
 
-  private int requestCode;
-  private boolean available;
-  private boolean canSubscribe;
-  private boolean canPurchaseItems;
+    private Logger logger;
+    private String developerPayload;
+    private Product pendingProduct;
+    private PurchaseListener purchaseListener;
+    private InitializationListener initializationListener;
 
-  private final AbstractInAppBillingV3API.LifecycleListener lifecycleListener
-      = new AbstractInAppBillingV3API.LifecycleListener() {
+    private int requestCode;
+    private boolean available;
+    private boolean canSubscribe;
+    private boolean canPurchaseItems;
+
+    private Executor executor = Executors.newSingleThreadExecutor();
+
+    private final AbstractInAppBillingV3API.LifecycleListener lifecycleListener
+            = new AbstractInAppBillingV3API.LifecycleListener() {
+        @Override
+        public void initialized(boolean success) {
+            log("initialized: success=" + success);
+            if (!success) {
+                logAndDisable("Couldn't create InAppBillingService instance");
+                return;
+            }
+
+            try {
+                canPurchaseItems
+                        = api.isBillingSupported(PRODUCT_TYPE_ITEM) == BILLING_RESPONSE_RESULT_OK;
+
+                canSubscribe
+                        = api.isBillingSupported(PRODUCT_TYPE_SUBSCRIPTION) == BILLING_RESPONSE_RESULT_OK;
+
+                available = canPurchaseItems || canSubscribe;
+                log("Connected to service and it is " + (available ? "available" : "not available"));
+                initializationListener.initialized();
+            } catch (RemoteException e) {
+                logAndDisable(Log.getStackTraceString(e));
+            }
+        }
+
+        @Override
+        public void disconnected() {
+            logAndDisable("Disconnected from service");
+        }
+    };
+
+    public InAppBillingV3Vendor() {
+        this(new InAppBillingV3API(), null);
+    }
+
+    public InAppBillingV3Vendor(String publicKey64) {
+        this(new InAppBillingV3API(), publicKey64);
+    }
+
+    public InAppBillingV3Vendor(AbstractInAppBillingV3API api) {
+        this(api, null);
+    }
+
+    public InAppBillingV3Vendor(AbstractInAppBillingV3API api, @Nullable String publicKey64) {
+        if (api == null) {
+            throw new IllegalArgumentException("Null api");
+        }
+
+        this.api = api;
+        this.publicKey64 = publicKey64;
+        available = false;
+    }
+
     @Override
-    public void initialized(boolean success) {
-      log("initialized: success=" + success);
-      if (!success) {
-        logAndDisable("Couldn't create InAppBillingService instance");
-        return;
-      }
-
-      try {
-        canPurchaseItems
-            = api.isBillingSupported(PRODUCT_TYPE_ITEM) == BILLING_RESPONSE_RESULT_OK;
-
-        canSubscribe
-            = api.isBillingSupported(PRODUCT_TYPE_SUBSCRIPTION) == BILLING_RESPONSE_RESULT_OK;
-
-        available = canPurchaseItems || canSubscribe;
-        log("Connected to service and it is " + (available ? "available" : "not available"));
-        initializationListener.initialized();
-      } catch (RemoteException e) {
-        logAndDisable(Log.getStackTraceString(e));
-      }
+    public String id() {
+        return VENDOR_PACKAGE;
     }
 
     @Override
-    public void disconnected() {
-      logAndDisable("Disconnected from service");
-    }
-  };
-
-  public InAppBillingV3Vendor() {
-    this(new InAppBillingV3API(), null);
-  }
-
-  public InAppBillingV3Vendor(String publicKey64) {
-    this(new InAppBillingV3API(), publicKey64);
-  }
-
-  public InAppBillingV3Vendor(AbstractInAppBillingV3API api) {
-    this(api, null);
-  }
-
-  public InAppBillingV3Vendor(AbstractInAppBillingV3API api, @Nullable String publicKey64) {
-    if (api == null) {
-      throw new IllegalArgumentException("Null api");
-    }
-
-    this.api = api;
-    this.publicKey64 = publicKey64;
-    available = false;
-  }
-
-  @Override
-  public String id() {
-    return VENDOR_PACKAGE;
-  }
-
-  @Override
-  public void initialize(Context context, InitializationListener listener) {
-    if (context == null || listener == null) {
-      throw new IllegalArgumentException("Context or initialization listener is null");
-    }
-
-    initializationListener = listener;
-
-    if (available()) {
-      listener.initialized();
-      return;
-    }
-
-    log("Initializing In-App billing v3...");
-    available = api.initialize(context, this, lifecycleListener, logger);
-
-    if (!available) {
-      initializationListener.unavailable();
-    }
-  }
-
-  @Override
-  public void dispose(Context context) {
-    if (context == null) {
-      throw new IllegalArgumentException("Given null context");
-    }
-    log("Disposing self...");
-    api.dispose(context);
-    available = false;
-  }
-
-  @Override
-  public boolean available() {
-    return available && api.available() && canPurchaseAnything();
-  }
-
-  int getRequestCode() {
-    return requestCode;
-  }
-
-  @Override
-  public boolean canPurchase(Product product) {
-    if (!canPurchaseAnything()) {
-      return false;
-    }
-
-    if (product.isSubscription() && !canSubscribe) {
-      return false;
-    }
-
-    if (!product.isSubscription() && !canPurchaseItems) {
-      return false;
-    }
-
-    // TODO: Maybe query inventory and match skus
-
-    return true;
-  }
-
-  @Override
-  public void purchase(Activity activity, Product product, String developerPayload,
-                       PurchaseListener listener) {
-    if (activity == null || product == null || listener == null) {
-      throw new IllegalArgumentException("Activity, product, or listener is null");
-    }
-
-    throwIfUninitialized();
-
-    if (!canPurchase(product)) {
-      throw new IllegalArgumentException("Cannot purchase given product!" + product.toString());
-    }
-
-    log("Constructing buy intent...");
-    final String type = product.isSubscription() ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
-    try {
-      if (developerPayload == null) {
-        this.developerPayload = UUID.randomUUID().toString();
-      } else {
-        this.developerPayload = developerPayload;
-      }
-
-      final Bundle buyBundle = api.getBuyIntent(product.sku(), type, developerPayload);
-      final int response = getResponseCode(buyBundle);
-      if (response != BILLING_RESPONSE_RESULT_OK) {
-        log("Couldn't purchase product! code:" + response);
-        listener.failure(product, purchaseError(response));
-        return;
-      }
-
-      final PendingIntent pendingIntent = buyBundle.getParcelable(RESPONSE_BUY_INTENT);
-      if (pendingIntent == null) {
-        log("Received no pending intent!");
-        listener.failure(product, purchaseError(response));
-        return;
-      }
-
-      log("Launching buy intent for " + product.sku());
-      this.purchaseListener = listener;
-      pendingProduct = product;
-      requestCode = new Random().nextInt(1024);
-      activity.startIntentSenderForResult(pendingIntent.getIntentSender(),
-          requestCode,
-          new Intent(), 0, 0, 0);
-    } catch (RemoteException | IntentSender.SendIntentException e) {
-      log("Failed to launch purchase!\n" + Log.getStackTraceString(e));
-      listener.failure(product, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
-    }
-  }
-
-  @Override
-  public void consume(Context context, Purchase purchase, ConsumeListener listener) {
-    if (context == null || purchase == null || listener == null) {
-      throw new IllegalArgumentException("Context, product, or listener is null");
-    }
-
-    throwIfUninitialized();
-
-    final Product product = purchase.product();
-    if (product.isSubscription()) {
-      throw new IllegalArgumentException("Cannot consume a subscription!");
-    }
-
-    try {
-      log("Consuming " + product.sku() + " " + purchase.token());
-      final int response = api.consumePurchase(purchase.token());
-      if (response == BILLING_RESPONSE_RESULT_OK) {
-        log("Successfully consumed purchase!");
-        listener.success(purchase);
-      } else {
-        log("Couldn't consume purchase! " + response);
-        listener.failure(purchase, consumeError(response));
-      }
-    } catch (RemoteException e) {
-      log("Couldn't consume purchase! " + Log.getStackTraceString(e));
-      listener.failure(purchase, consumeError(BILLING_RESPONSE_RESULT_ERROR));
-    }
-  }
-
-  @Override
-  public void getInventory(Context context, Collection<String> inappSkus, Collection<String> subSkus,
-                           InventoryListener listener) {
-    if (context == null || listener == null) {
-      throw new IllegalArgumentException("Context or listener is null");
-    }
-
-    throwIfUninitialized();
-
-    // Convert the given collections to a list
-    final List<String> inappSkusList = inappSkus == null ? null : new ArrayList<>(inappSkus);
-    final List<String> subSkusList = subSkus == null ? null : new ArrayList<>(subSkus);
-
-    final Inventory inventory = new Inventory();
-    try {
-      log("Querying inventory...");
-      inventory.addPurchases(getPurchases(PRODUCT_TYPE_ITEM));
-      inventory.addPurchases(getPurchases(PRODUCT_TYPE_SUBSCRIPTION));
-
-      if (inappSkusList != null && !inappSkusList.isEmpty()) {
-        inventory.addProducts(getProductsWithType(inappSkusList, PRODUCT_TYPE_ITEM));
-      }
-
-      if (subSkusList != null && !subSkusList.isEmpty()) {
-        inventory.addProducts(getProductsWithType(subSkusList, PRODUCT_TYPE_SUBSCRIPTION));
-      }
-
-      listener.success(inventory);
-    } catch (RemoteException | ApiException e) {
-      listener.failure(new Vendor.Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
-    } catch (JSONException e) {
-      listener.failure(new Vendor.Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
-    }
-  }
-
-  @Override
-  public void getProductDetails(Context context, String sku, boolean isSubscription,
-                                ProductDetailsListener listener) {
-    if (context == null || sku == null || listener == null) {
-      throw new IllegalArgumentException("Context or sku or listener is null");
-    }
-    throwIfUninitialized();
-    final String type = isSubscription ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
-    try {
-      final List<Product> productList = getProductsWithType(Collections.singletonList(sku), type);
-      if (productList.isEmpty()) {
-        listener.failure(new Vendor.Error(PRODUCT_DETAILS_NOT_FOUND, -1));
-        return;
-      }
-
-      listener.success(productList.get(0));
-    } catch (RemoteException | ApiException e) {
-      listener.failure(new Vendor.Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
-    }
-  }
-
-  private List<InAppBillingPurchase> getPurchases(String type)
-      throws RemoteException, ApiException, JSONException {
-    throwIfUninitialized();
-    if (type.equals(PRODUCT_TYPE_ITEM)) {
-      log("Querying item purchases...");
-    } else {
-      log("Querying subscription purchases...");
-    }
-    String paginationToken = null;
-    final List<InAppBillingPurchase> purchaseList = new ArrayList<>();
-    do {
-      final Bundle purchases = api.getPurchases(type, paginationToken);
-
-      final int response = getResponseCode(purchases);
-      log("Got response: " + response);
-      if (response != BILLING_RESPONSE_RESULT_OK) {
-        throw new ApiException(response);
-      }
-
-      if (!purchases.containsKey(RESPONSE_INAPP_ITEM_LIST)
-          || !purchases.containsKey(RESPONSE_INAPP_PURCHASE_DATA_LIST)
-          || !purchases.containsKey(RESPONSE_INAPP_SIGNATURE_LIST)) {
-        throw new ApiException(BILLING_RESPONSE_RESULT_ERROR);
-      }
-
-      final List<String> purchasedSkus
-          = purchases.getStringArrayList(RESPONSE_INAPP_ITEM_LIST);
-      final List<String> purchaseDataList
-          = purchases.getStringArrayList(RESPONSE_INAPP_PURCHASE_DATA_LIST);
-      final List<String> signatureList
-          = purchases.getStringArrayList(RESPONSE_INAPP_SIGNATURE_LIST);
-
-      if (purchasedSkus == null || purchaseDataList == null || signatureList == null) {
-        return Collections.emptyList();
-      }
-
-      final List<Product> purchasedProducts = getProductsWithType(purchasedSkus, type);
-
-      for (int i = 0; i < purchaseDataList.size(); ++i) {
-        final String purchaseData = purchaseDataList.get(i);
-        final String sku = purchasedSkus.get(i);
-        final String signature = signatureList.get(i);
-
-        Product product = null;
-        for (final Product maybeProduct : purchasedProducts) {
-          if (sku.equals(maybeProduct.sku())) {
-            product = maybeProduct;
-            break;
-          }
+    public void initialize(Context context, InitializationListener listener) {
+        if (context == null || listener == null) {
+            throw new IllegalArgumentException("Context or initialization listener is null");
         }
 
-        if (product == null) {
-          // TODO: Should raise this as an error to the user
-          continue;
+        initializationListener = listener;
+
+        if (available()) {
+            listener.initialized();
+            return;
         }
 
-        log("Found purchase: " + sku);
-        if (!TextUtils.isEmpty(publicKey64)) {
-          if (InAppBillingSecurity.verifySignature(publicKey64, purchaseData, signature)) {
-            log("Purchase locally verified: " + sku);
-          } else {
-            log("Purchase not locally verified: " + sku);
-            continue;
-          }
+        log("Initializing In-App billing v3...");
+        available = api.initialize(context, this, lifecycleListener, logger);
+
+        if (!available) {
+            initializationListener.unavailable();
+        }
+    }
+
+    @Override
+    public void dispose(Context context) {
+        if (context == null) {
+            throw new IllegalArgumentException("Given null context");
+        }
+        log("Disposing self...");
+        api.dispose(context);
+        available = false;
+    }
+
+    @Override
+    public boolean available() {
+        return available && api.available() && canPurchaseAnything();
+    }
+
+    int getRequestCode() {
+        return requestCode;
+    }
+
+    @Override
+    public boolean canPurchase(Product product) {
+        if (!canPurchaseAnything()) {
+            return false;
         }
 
-        purchaseList.add(InAppBillingPurchase.create(product, purchaseData, signature));
-      }
+        if (product.isSubscription() && !canSubscribe) {
+            return false;
+        }
 
-      paginationToken = purchases.getString(INAPP_CONTINUATION_TOKEN);
-      if (paginationToken != null) {
-        log("Pagination token found, continuing on....");
-      }
-    } while (!TextUtils.isEmpty(paginationToken));
+        if (!product.isSubscription() && !canPurchaseItems) {
+            return false;
+        }
 
-    return Collections.unmodifiableList(purchaseList);
-  }
+        // TODO: Maybe query inventory and match skus
 
-  private List<Product> getProductsWithType(List<String> skus, String type)
-      throws RemoteException, ApiException {
-    if (skus == null || TextUtils.isEmpty(type)) {
-      throw new IllegalArgumentException("Given skus are null or type is empty/null");
+        return true;
     }
 
-    throwIfUninitialized();
-    log("Retrieving sku details for " + skus.size() + " " + type + " skus");
-    if (!type.equals(PRODUCT_TYPE_ITEM) && !type.equals(PRODUCT_TYPE_SUBSCRIPTION)) {
-      throw new IllegalArgumentException("Invalid product type " + type);
-    }
+    @Override
+    public void purchase(Activity activity, Product product, String developerPayload,
+                         PurchaseListener listener) {
+        if (activity == null || product == null || listener == null) {
+            throw new IllegalArgumentException("Activity, product, or listener is null");
+        }
 
-    final List<Product> products = new ArrayList<>();
-    for (int i = 0; i < skus.size(); i += 20) {
-      final ArrayList<String> page = new ArrayList<>(skus.subList(i, Math.min(skus.size(), i + 20)));
-      final Bundle skuQuery = new Bundle();
-      skuQuery.putStringArrayList(REQUEST_SKU_DETAILS_ITEM_LIST, page);
+        throwIfUninitialized();
 
-      final Bundle skuDetails = api.getSkuDetails(type, skuQuery);
-      final int response = getResponseCode(skuDetails);
-      log("Got response: " + response);
-      if (skuDetails == null) {
-        continue;
-      }
+        if (!canPurchase(product)) {
+            throw new IllegalArgumentException("Cannot purchase given product!" + product.toString());
+        }
 
-      if (response != BILLING_RESPONSE_RESULT_OK || !skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
-        throw new ApiException(response);
-      }
-
-      final ArrayList<String> detailsList
-          = skuDetails.getStringArrayList(RESPONSE_GET_SKU_DETAILS_LIST);
-      if (detailsList == null) continue;
-
-      for (final String detail : detailsList) {
-        log("Parsing sku details: " + detail);
+        log("Constructing buy intent...");
+        final String type = product.isSubscription() ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
         try {
-          products.add(InAppBillingProduct.create(detail, type.equals(PRODUCT_TYPE_SUBSCRIPTION)));
-        } catch (JSONException e) {
-          log("Couldn't parse sku: " + detail);
+            if (developerPayload == null) {
+                this.developerPayload = UUID.randomUUID().toString();
+            } else {
+                this.developerPayload = developerPayload;
+            }
+
+            final Bundle buyBundle = api.getBuyIntent(product.sku(), type, developerPayload);
+            final int response = getResponseCode(buyBundle);
+            if (response != BILLING_RESPONSE_RESULT_OK) {
+                log("Couldn't purchase product! code:" + response);
+                listener.failure(product, purchaseError(response));
+                return;
+            }
+
+            final PendingIntent pendingIntent = buyBundle.getParcelable(RESPONSE_BUY_INTENT);
+            if (pendingIntent == null) {
+                log("Received no pending intent!");
+                listener.failure(product, purchaseError(response));
+                return;
+            }
+
+            log("Launching buy intent for " + product.sku());
+            this.purchaseListener = listener;
+            pendingProduct = product;
+            requestCode = new Random().nextInt(1024);
+            activity.startIntentSenderForResult(pendingIntent.getIntentSender(),
+                    requestCode,
+                    new Intent(), 0, 0, 0);
+        } catch (RemoteException | IntentSender.SendIntentException e) {
+            log("Failed to launch purchase!\n" + Log.getStackTraceString(e));
+            listener.failure(product, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
         }
-      }
     }
 
-    return Collections.unmodifiableList(products);
-  }
-
-  @Override
-  public void setLogger(@Nullable Logger logger) {
-    this.logger = logger;
-  }
-
-  @Override
-  public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
-    log("onActivityResult " + resultCode);
-    if (this.requestCode != requestCode) {
-      return false;
-    }
-
-    if (data == null) {
-      purchaseListener.failure(pendingProduct, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
-      return true;
-    }
-
-    final int responseCode = getResponseCode(data);
-    if (resultCode == Activity.RESULT_OK && responseCode == BILLING_RESPONSE_RESULT_OK) {
-      try {
-        final InAppBillingPurchase purchase = InAppBillingPurchase.create(pendingProduct, data);
-        if (!purchase.developerPayload().equals(developerPayload)) {
-          log("Developer payload mismatch!");
-          purchaseListener.failure(pendingProduct,
-              new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                  BILLING_RESPONSE_RESULT_ERROR));
-          return true;
-        }
-
-        if (!TextUtils.isEmpty(publicKey64)
-            && !InAppBillingSecurity.verifySignature(publicKey64, purchase.receipt(), purchase.dataSignature())) {
-          log("Local signature check failed!");
-          purchaseListener.failure(pendingProduct,
-              new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                  BILLING_RESPONSE_RESULT_ERROR));
-          return true;
+    @Override
+    public void consume(Context context, Purchase purchase, ConsumeListener listener) {
+        if (context == null || purchase == null || listener == null) {
+            throw new IllegalArgumentException("Context, product, or listener is null");
         }
 
-        log("Successful purchase of " + pendingProduct.sku() + "!");
-        purchaseListener.success(purchase);
-        developerPayload = null;
-      } catch (JSONException e) {
-        purchaseListener.failure(pendingProduct,
-            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                BILLING_RESPONSE_RESULT_ERROR));
-      }
-    } else if (resultCode == Activity.RESULT_OK) {
-      log("CashierPurchase failed! " + responseCode);
-      purchaseListener.failure(pendingProduct, purchaseError(responseCode));
-    } else {
-      log("CashierPurchase canceled! " + responseCode);
-      purchaseListener.failure(pendingProduct, purchaseError(responseCode));
+        throwIfUninitialized();
+
+        final Product product = purchase.product();
+        if (product.isSubscription()) {
+            throw new IllegalArgumentException("Cannot consume a subscription!");
+        }
+
+        try {
+            log("Consuming " + product.sku() + " " + purchase.token());
+            final int response = api.consumePurchase(purchase.token());
+            if (response == BILLING_RESPONSE_RESULT_OK) {
+                log("Successfully consumed purchase!");
+                listener.success(purchase);
+            } else {
+                log("Couldn't consume purchase! " + response);
+                listener.failure(purchase, consumeError(response));
+            }
+        } catch (RemoteException e) {
+            log("Couldn't consume purchase! " + Log.getStackTraceString(e));
+            listener.failure(purchase, consumeError(BILLING_RESPONSE_RESULT_ERROR));
+        }
     }
 
-    return true;
-  }
+    @Override
+    public void getInventory(Context context, final Collection<String> inappSkus, final Collection<String> subSkus,
+                             final InventoryListener listener) {
+        if (context == null || listener == null) {
+            throw new IllegalArgumentException("Context or listener is null");
+        }
 
-  @Override
-  public Product getProductFrom(JSONObject json) throws JSONException {
-    final Product product = Product.create(json);
-    if (!product.vendorId().equals(VENDOR_PACKAGE)) {
-      throw new IllegalArgumentException("This product does not belong to Google Play");
+        throwIfUninitialized();
+        final Handler caller = new Handler();
+        Runnable skuTask = new Runnable() {
+            @Override
+            public void run() {
+                // Convert the given collections to a list
+                final List<String> inappSkusList = inappSkus == null ? null : new ArrayList<>(inappSkus);
+                final List<String> subSkusList = subSkus == null ? null : new ArrayList<>(subSkus);
+
+                final Inventory inventory = new Inventory();
+                try {
+                    log("Querying inventory...");
+                    inventory.addPurchases(getPurchases(PRODUCT_TYPE_ITEM));
+                    inventory.addPurchases(getPurchases(PRODUCT_TYPE_SUBSCRIPTION));
+
+                    if (inappSkusList != null && !inappSkusList.isEmpty()) {
+                        inventory.addProducts(getProductsWithType(inappSkusList, PRODUCT_TYPE_ITEM));
+                    }
+
+                    if (subSkusList != null && !subSkusList.isEmpty()) {
+                        inventory.addProducts(getProductsWithType(subSkusList, PRODUCT_TYPE_SUBSCRIPTION));
+                    }
+
+                    caller.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            listener.success(inventory);
+                        }
+                    });
+                } catch (RemoteException | ApiException e) {
+                    caller.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            listener.failure(new Vendor.Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
+                        }
+                    });
+                } catch (JSONException e) {
+                    caller.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            listener.failure(new Vendor.Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
+                        }
+                    });
+                }
+            }
+        };
+
+        if (DISABLE_EXECUTOR) {
+            caller.post(skuTask);
+        } else {
+            executor.execute(skuTask);
+        }
     }
 
-    return product;
-  }
+    @Override
+    public void getProductDetails(Context context, String sku, boolean isSubscription,
+                                  ProductDetailsListener listener) {
+        if (context == null || sku == null || listener == null) {
+            throw new IllegalArgumentException("Context or sku or listener is null");
+        }
+        throwIfUninitialized();
+        final String type = isSubscription ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
+        try {
+            final List<Product> productList = getProductsWithType(Collections.singletonList(sku), type);
+            if (productList.isEmpty()) {
+                listener.failure(new Vendor.Error(PRODUCT_DETAILS_NOT_FOUND, -1));
+                return;
+            }
 
-  @Override
-  public Purchase getPurchaseFrom(JSONObject json) throws JSONException {
-    final InAppBillingPurchase purchase = InAppBillingPurchase.create(json);
-    if (!purchase.product().vendorId().equals(VENDOR_PACKAGE)) {
-      throw new IllegalArgumentException("This purchase does not belong to Google Play");
+            listener.success(productList.get(0));
+        } catch (RemoteException | ApiException e) {
+            listener.failure(new Vendor.Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
+        }
     }
 
-    return purchase;
-  }
+    private List<InAppBillingPurchase> getPurchases(String type)
+            throws RemoteException, ApiException, JSONException {
+        throwIfUninitialized();
+        if (type.equals(PRODUCT_TYPE_ITEM)) {
+            log("Querying item purchases...");
+        } else {
+            log("Querying subscription purchases...");
+        }
+        String paginationToken = null;
+        final List<InAppBillingPurchase> purchaseList = new ArrayList<>();
+        do {
+            final Bundle purchases = api.getPurchases(type, paginationToken);
 
-  private void throwIfUninitialized() {
-    if (!api.available()) {
-      throw new IllegalStateException("Trying to purchase without initializing first!");
-    }
-  }
+            final int response = getResponseCode(purchases);
+            log("Got response: " + response);
+            if (response != BILLING_RESPONSE_RESULT_OK) {
+                throw new ApiException(response);
+            }
 
-  private boolean canPurchaseAnything() {
-    return canPurchaseItems || canSubscribe;
-  }
+            if (!purchases.containsKey(RESPONSE_INAPP_ITEM_LIST)
+                    || !purchases.containsKey(RESPONSE_INAPP_PURCHASE_DATA_LIST)
+                    || !purchases.containsKey(RESPONSE_INAPP_SIGNATURE_LIST)) {
+                throw new ApiException(BILLING_RESPONSE_RESULT_ERROR);
+            }
 
-  private void logAndDisable(String message) {
-    log(message);
-    available = false;
-  }
+            final List<String> purchasedSkus
+                    = purchases.getStringArrayList(RESPONSE_INAPP_ITEM_LIST);
+            final List<String> purchaseDataList
+                    = purchases.getStringArrayList(RESPONSE_INAPP_PURCHASE_DATA_LIST);
+            final List<String> signatureList
+                    = purchases.getStringArrayList(RESPONSE_INAPP_SIGNATURE_LIST);
 
-  private int getResponseCode(Intent intent) {
-    final Bundle extras = intent.getExtras();
-    return getResponseCode(extras);
-  }
+            if (purchasedSkus == null || purchaseDataList == null || signatureList == null) {
+                return Collections.emptyList();
+            }
 
-  private int getResponseCode(Bundle bundle) {
-    if (bundle == null) {
-      log("Null response code from bundle, assuming OK (known issue)");
-      return BILLING_RESPONSE_RESULT_OK;
-    }
+            final List<Product> purchasedProducts = getProductsWithType(purchasedSkus, type);
 
-    final Object o = bundle.get(RESPONSE_CODE);
-    if (o == null) {
-      log("Null response code from bundle, assuming OK (known issue)");
-      return BILLING_RESPONSE_RESULT_OK;
-    } else if (o instanceof Integer) {
-      return (Integer) o;
-    } else if (o instanceof Long) {
-      return ((Long) o).intValue();
-    } else {
-      final String message = "Unexpected type for bundle response code. " + o.getClass().getName();
-      log(message);
-      throw new RuntimeException(message);
-    }
-  }
+            for (int i = 0; i < purchaseDataList.size(); ++i) {
+                final String purchaseData = purchaseDataList.get(i);
+                final String sku = purchasedSkus.get(i);
+                final String signature = signatureList.get(i);
 
-  private int codeFromException(Exception e) {
-    if (e instanceof ApiException) {
-      return ((ApiException) e).code;
-    }
+                Product product = null;
+                for (final Product maybeProduct : purchasedProducts) {
+                    if (sku.equals(maybeProduct.sku())) {
+                        product = maybeProduct;
+                        break;
+                    }
+                }
 
-    return -1;
-  }
+                if (product == null) {
+                    // TODO: Should raise this as an error to the user
+                    continue;
+                }
 
-  private Vendor.Error purchaseError(int response) {
-    final int code;
-    switch (response) {
-      case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
-      case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-        code = PURCHASE_UNAVAILABLE;
-        break;
-      case BILLING_RESPONSE_RESULT_USER_CANCELED:
-        code = PURCHASE_CANCELED;
-        break;
-      case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
-        code = PURCHASE_ALREADY_OWNED;
-        break;
-      case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-        code = PURCHASE_NOT_OWNED;
-        break;
-      case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-      case BILLING_RESPONSE_RESULT_ERROR:
-      default:
-        code = PURCHASE_FAILURE;
-        break;
-    }
+                log("Found purchase: " + sku);
+                if (!TextUtils.isEmpty(publicKey64)) {
+                    if (InAppBillingSecurity.verifySignature(publicKey64, purchaseData, signature)) {
+                        log("Purchase locally verified: " + sku);
+                    } else {
+                        log("Purchase not locally verified: " + sku);
+                        continue;
+                    }
+                }
 
-    return new Vendor.Error(code, response);
-  }
+                purchaseList.add(InAppBillingPurchase.create(product, purchaseData, signature));
+            }
 
-  private Vendor.Error consumeError(int response) {
-    final int code;
-    switch (response) {
-      case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
-      case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-        code = CONSUME_UNAVAILABLE;
-        break;
-      case BILLING_RESPONSE_RESULT_USER_CANCELED:
-        code = CONSUME_CANCELED;
-        break;
-      case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-        code = CONSUME_NOT_OWNED;
-        break;
-      case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-      case BILLING_RESPONSE_RESULT_ERROR:
-      default:
-        code = CONSUME_FAILURE;
-        break;
+            paginationToken = purchases.getString(INAPP_CONTINUATION_TOKEN);
+            if (paginationToken != null) {
+                log("Pagination token found, continuing on....");
+            }
+        } while (!TextUtils.isEmpty(paginationToken));
+
+        return Collections.unmodifiableList(purchaseList);
     }
 
-    return new Vendor.Error(code, response);
-  }
+    private List<Product> getProductsWithType(List<String> skus, String type)
+            throws RemoteException, ApiException {
+        if (skus == null || TextUtils.isEmpty(type)) {
+            throw new IllegalArgumentException("Given skus are null or type is empty/null");
+        }
 
-  private void log(String message) {
-    if (logger == null) return;
-    logger.i("InAppBillingV3Vendor", message);
-  }
+        throwIfUninitialized();
+        log("Retrieving sku details for " + skus.size() + " " + type + " skus");
+        if (!type.equals(PRODUCT_TYPE_ITEM) && !type.equals(PRODUCT_TYPE_SUBSCRIPTION)) {
+            throw new IllegalArgumentException("Invalid product type " + type);
+        }
 
-  private class ApiException extends Exception {
-    private final int code;
+        final List<Product> products = new ArrayList<>();
+        for (int i = 0; i < skus.size(); i += 20) {
+            final ArrayList<String> page = new ArrayList<>(skus.subList(i, Math.min(skus.size(), i + 20)));
+            final Bundle skuQuery = new Bundle();
+            skuQuery.putStringArrayList(REQUEST_SKU_DETAILS_ITEM_LIST, page);
 
-    public ApiException(final int code) {
-      super("Received Billing API response " + code);
-      this.code = code;
+            final Bundle skuDetails = api.getSkuDetails(type, skuQuery);
+            final int response = getResponseCode(skuDetails);
+            log("Got response: " + response);
+            if (skuDetails == null) {
+                continue;
+            }
+
+            if (response != BILLING_RESPONSE_RESULT_OK || !skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
+                throw new ApiException(response);
+            }
+
+            final ArrayList<String> detailsList
+                    = skuDetails.getStringArrayList(RESPONSE_GET_SKU_DETAILS_LIST);
+            if (detailsList == null) continue;
+
+            for (final String detail : detailsList) {
+                log("Parsing sku details: " + detail);
+                try {
+                    products.add(InAppBillingProduct.create(detail, type.equals(PRODUCT_TYPE_SUBSCRIPTION)));
+                } catch (JSONException e) {
+                    log("Couldn't parse sku: " + detail);
+                }
+            }
+        }
+
+        return Collections.unmodifiableList(products);
     }
 
-    public int code() {
-      return code;
+    @Override
+    public void setLogger(@Nullable Logger logger) {
+        this.logger = logger;
     }
-  }
+
+    @Override
+    public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+        log("onActivityResult " + resultCode);
+        if (this.requestCode != requestCode) {
+            return false;
+        }
+
+        if (data == null) {
+            purchaseListener.failure(pendingProduct, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
+            return true;
+        }
+
+        final int responseCode = getResponseCode(data);
+        if (resultCode == Activity.RESULT_OK && responseCode == BILLING_RESPONSE_RESULT_OK) {
+            try {
+                final InAppBillingPurchase purchase = InAppBillingPurchase.create(pendingProduct, data);
+                if (!purchase.developerPayload().equals(developerPayload)) {
+                    log("Developer payload mismatch!");
+                    purchaseListener.failure(pendingProduct,
+                            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                                    BILLING_RESPONSE_RESULT_ERROR));
+                    return true;
+                }
+
+                if (!TextUtils.isEmpty(publicKey64)
+                        && !InAppBillingSecurity.verifySignature(publicKey64, purchase.receipt(), purchase.dataSignature())) {
+                    log("Local signature check failed!");
+                    purchaseListener.failure(pendingProduct,
+                            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                                    BILLING_RESPONSE_RESULT_ERROR));
+                    return true;
+                }
+
+                log("Successful purchase of " + pendingProduct.sku() + "!");
+                purchaseListener.success(purchase);
+                developerPayload = null;
+            } catch (JSONException e) {
+                purchaseListener.failure(pendingProduct,
+                        new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                                BILLING_RESPONSE_RESULT_ERROR));
+            }
+        } else if (resultCode == Activity.RESULT_OK) {
+            log("CashierPurchase failed! " + responseCode);
+            purchaseListener.failure(pendingProduct, purchaseError(responseCode));
+        } else {
+            log("CashierPurchase canceled! " + responseCode);
+            purchaseListener.failure(pendingProduct, purchaseError(responseCode));
+        }
+
+        return true;
+    }
+
+    @Override
+    public Product getProductFrom(JSONObject json) throws JSONException {
+        final Product product = Product.create(json);
+        if (!product.vendorId().equals(VENDOR_PACKAGE)) {
+            throw new IllegalArgumentException("This product does not belong to Google Play");
+        }
+
+        return product;
+    }
+
+    @Override
+    public Purchase getPurchaseFrom(JSONObject json) throws JSONException {
+        final InAppBillingPurchase purchase = InAppBillingPurchase.create(json);
+        if (!purchase.product().vendorId().equals(VENDOR_PACKAGE)) {
+            throw new IllegalArgumentException("This purchase does not belong to Google Play");
+        }
+
+        return purchase;
+    }
+
+    private void throwIfUninitialized() {
+        if (!api.available()) {
+            throw new IllegalStateException("Trying to purchase without initializing first!");
+        }
+    }
+
+    private boolean canPurchaseAnything() {
+        return canPurchaseItems || canSubscribe;
+    }
+
+    private void logAndDisable(String message) {
+        log(message);
+        available = false;
+    }
+
+    private int getResponseCode(Intent intent) {
+        final Bundle extras = intent.getExtras();
+        return getResponseCode(extras);
+    }
+
+    private int getResponseCode(Bundle bundle) {
+        if (bundle == null) {
+            log("Null response code from bundle, assuming OK (known issue)");
+            return BILLING_RESPONSE_RESULT_OK;
+        }
+
+        final Object o = bundle.get(RESPONSE_CODE);
+        if (o == null) {
+            log("Null response code from bundle, assuming OK (known issue)");
+            return BILLING_RESPONSE_RESULT_OK;
+        } else if (o instanceof Integer) {
+            return (Integer) o;
+        } else if (o instanceof Long) {
+            return ((Long) o).intValue();
+        } else {
+            final String message = "Unexpected type for bundle response code. " + o.getClass().getName();
+            log(message);
+            throw new RuntimeException(message);
+        }
+    }
+
+    private int codeFromException(Exception e) {
+        if (e instanceof ApiException) {
+            return ((ApiException) e).code;
+        }
+
+        return -1;
+    }
+
+    private Vendor.Error purchaseError(int response) {
+        final int code;
+        switch (response) {
+            case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
+            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+                code = PURCHASE_UNAVAILABLE;
+                break;
+            case BILLING_RESPONSE_RESULT_USER_CANCELED:
+                code = PURCHASE_CANCELED;
+                break;
+            case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
+                code = PURCHASE_ALREADY_OWNED;
+                break;
+            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+                code = PURCHASE_NOT_OWNED;
+                break;
+            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+            case BILLING_RESPONSE_RESULT_ERROR:
+            default:
+                code = PURCHASE_FAILURE;
+                break;
+        }
+
+        return new Vendor.Error(code, response);
+    }
+
+    private Vendor.Error consumeError(int response) {
+        final int code;
+        switch (response) {
+            case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
+            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+                code = CONSUME_UNAVAILABLE;
+                break;
+            case BILLING_RESPONSE_RESULT_USER_CANCELED:
+                code = CONSUME_CANCELED;
+                break;
+            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+                code = CONSUME_NOT_OWNED;
+                break;
+            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+            case BILLING_RESPONSE_RESULT_ERROR:
+            default:
+                code = CONSUME_FAILURE;
+                break;
+        }
+
+        return new Vendor.Error(code, response);
+    }
+
+    private void log(String message) {
+        if (logger == null) return;
+        logger.i("InAppBillingV3Vendor", message);
+    }
+
+    private class ApiException extends Exception {
+        private final int code;
+
+        public ApiException(final int code) {
+            super("Received Billing API response " + code);
+            this.code = code;
+        }
+
+        public int code() {
+            return code;
+        }
+    }
 }

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -57,6 +57,7 @@ import static com.getkeepsafe.cashier.VendorConstants.CONSUME_NOT_OWNED;
 import static com.getkeepsafe.cashier.VendorConstants.CONSUME_UNAVAILABLE;
 import static com.getkeepsafe.cashier.VendorConstants.INVENTORY_QUERY_FAILURE;
 import static com.getkeepsafe.cashier.VendorConstants.INVENTORY_QUERY_MALFORMED_RESPONSE;
+import static com.getkeepsafe.cashier.VendorConstants.INVENTORY_QUERY_UNAVAILABLE;
 import static com.getkeepsafe.cashier.VendorConstants.PRODUCT_DETAILS_NOT_FOUND;
 import static com.getkeepsafe.cashier.VendorConstants.PRODUCT_DETAILS_QUERY_FAILURE;
 import static com.getkeepsafe.cashier.VendorConstants.PURCHASE_ALREADY_OWNED;
@@ -348,6 +349,14 @@ public class InAppBillingV3Vendor implements Vendor {
             @Override
             public void run() {
               listener.failure(new Vendor.Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
+            }
+          });
+        } catch (IllegalStateException e) {
+          // Fixes the race condition wherein billing can be null if the service connection gets disconnect
+          callThread.post(new Runnable() {
+            @Override
+            public void run() {
+             listener.failure(new Vendor.Error(INVENTORY_QUERY_UNAVAILABLE, -1));
             }
           });
         }

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -340,14 +340,14 @@ public class InAppBillingV3Vendor implements Vendor {
           callThread.post(new Runnable() {
             @Override
             public void run() {
-              listener.failure(new Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
+              listener.failure(new Vendor.Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
             }
           });
         } catch (JSONException e) {
           callThread.post(new Runnable() {
             @Override
             public void run() {
-              listener.failure(new Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
+              listener.failure(new Vendor.Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
             }
           });
         }
@@ -372,13 +372,13 @@ public class InAppBillingV3Vendor implements Vendor {
     try {
       final List<Product> productList = getProductsWithType(Collections.singletonList(sku), type);
       if (productList.isEmpty()) {
-        listener.failure(new Error(PRODUCT_DETAILS_NOT_FOUND, -1));
+        listener.failure(new Vendor.Error(PRODUCT_DETAILS_NOT_FOUND, -1));
         return;
       }
 
       listener.success(productList.get(0));
     } catch (RemoteException | ApiException e) {
-      listener.failure(new Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
+      listener.failure(new Vendor.Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
     }
   }
 
@@ -530,7 +530,7 @@ public class InAppBillingV3Vendor implements Vendor {
         if (!purchase.developerPayload().equals(developerPayload)) {
           log("Developer payload mismatch!");
           purchaseListener.failure(pendingProduct,
-              new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+              new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
                   BILLING_RESPONSE_RESULT_ERROR));
           return true;
         }
@@ -539,7 +539,7 @@ public class InAppBillingV3Vendor implements Vendor {
             && !InAppBillingSecurity.verifySignature(publicKey64, purchase.receipt(), purchase.dataSignature())) {
           log("Local signature check failed!");
           purchaseListener.failure(pendingProduct,
-              new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+              new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
                   BILLING_RESPONSE_RESULT_ERROR));
           return true;
         }
@@ -549,7 +549,7 @@ public class InAppBillingV3Vendor implements Vendor {
         developerPayload = null;
       } catch (JSONException e) {
         purchaseListener.failure(pendingProduct,
-            new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
                 BILLING_RESPONSE_RESULT_ERROR));
       }
     } else if (resultCode == Activity.RESULT_OK) {
@@ -655,7 +655,7 @@ public class InAppBillingV3Vendor implements Vendor {
         break;
     }
 
-    return new Error(code, response);
+    return new Vendor.Error(code, response);
   }
 
   private Error consumeError(int response) {
@@ -678,7 +678,7 @@ public class InAppBillingV3Vendor implements Vendor {
         break;
     }
 
-    return new Error(code, response);
+    return new Vendor.Error(code, response);
   }
 
   private void log(String message) {

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -86,617 +86,616 @@ import static com.getkeepsafe.cashier.iab.InAppBillingConstants.RESPONSE_INAPP_S
 import static com.getkeepsafe.cashier.iab.InAppBillingConstants.VENDOR_PACKAGE;
 
 public class InAppBillingV3Vendor implements Vendor {
+  @VisibleForTesting
+  static boolean DISABLE_EXECUTOR = false;
+  private final AbstractInAppBillingV3API api;
+  private final String publicKey64;
 
-    @VisibleForTesting
-    static boolean DISABLE_EXECUTOR = false;
-    private final AbstractInAppBillingV3API api;
-    private final String publicKey64;
+  private Logger logger;
+  private String developerPayload;
+  private Product pendingProduct;
+  private PurchaseListener purchaseListener;
+  private InitializationListener initializationListener;
 
-    private Logger logger;
-    private String developerPayload;
-    private Product pendingProduct;
-    private PurchaseListener purchaseListener;
-    private InitializationListener initializationListener;
+  private int requestCode;
+  private boolean available;
+  private boolean canSubscribe;
+  private boolean canPurchaseItems;
+  private Executor executor = Executors.newSingleThreadExecutor();
 
-    private int requestCode;
-    private boolean available;
-    private boolean canSubscribe;
-    private boolean canPurchaseItems;
+  private final AbstractInAppBillingV3API.LifecycleListener lifecycleListener
+      = new AbstractInAppBillingV3API.LifecycleListener() {
+    @Override
+    public void initialized(boolean success) {
+      log("initialized: success=" + success);
+      if (!success) {
+        logAndDisable("Couldn't create InAppBillingService instance");
+        return;
+      }
 
-    private Executor executor = Executors.newSingleThreadExecutor();
+      try {
+        canPurchaseItems
+            = api.isBillingSupported(PRODUCT_TYPE_ITEM) == BILLING_RESPONSE_RESULT_OK;
 
-    private final AbstractInAppBillingV3API.LifecycleListener lifecycleListener
-            = new AbstractInAppBillingV3API.LifecycleListener() {
-        @Override
-        public void initialized(boolean success) {
-            log("initialized: success=" + success);
-            if (!success) {
-                logAndDisable("Couldn't create InAppBillingService instance");
-                return;
-            }
+        canSubscribe
+            = api.isBillingSupported(PRODUCT_TYPE_SUBSCRIPTION) == BILLING_RESPONSE_RESULT_OK;
 
-            try {
-                canPurchaseItems
-                        = api.isBillingSupported(PRODUCT_TYPE_ITEM) == BILLING_RESPONSE_RESULT_OK;
-
-                canSubscribe
-                        = api.isBillingSupported(PRODUCT_TYPE_SUBSCRIPTION) == BILLING_RESPONSE_RESULT_OK;
-
-                available = canPurchaseItems || canSubscribe;
-                log("Connected to service and it is " + (available ? "available" : "not available"));
-                initializationListener.initialized();
-            } catch (RemoteException e) {
-                logAndDisable(Log.getStackTraceString(e));
-            }
-        }
-
-        @Override
-        public void disconnected() {
-            logAndDisable("Disconnected from service");
-        }
-    };
-
-    public InAppBillingV3Vendor() {
-        this(new InAppBillingV3API(), null);
-    }
-
-    public InAppBillingV3Vendor(String publicKey64) {
-        this(new InAppBillingV3API(), publicKey64);
-    }
-
-    public InAppBillingV3Vendor(AbstractInAppBillingV3API api) {
-        this(api, null);
-    }
-
-    public InAppBillingV3Vendor(AbstractInAppBillingV3API api, @Nullable String publicKey64) {
-        if (api == null) {
-            throw new IllegalArgumentException("Null api");
-        }
-
-        this.api = api;
-        this.publicKey64 = publicKey64;
-        available = false;
+        available = canPurchaseItems || canSubscribe;
+        log("Connected to service and it is " + (available ? "available" : "not available"));
+        initializationListener.initialized();
+      } catch (RemoteException e) {
+        logAndDisable(Log.getStackTraceString(e));
+      }
     }
 
     @Override
-    public String id() {
-        return VENDOR_PACKAGE;
+    public void disconnected() {
+      logAndDisable("Disconnected from service");
+    }
+  };
+
+  public InAppBillingV3Vendor() {
+    this(new InAppBillingV3API(), null);
+  }
+
+  public InAppBillingV3Vendor(String publicKey64) {
+    this(new InAppBillingV3API(), publicKey64);
+  }
+
+  public InAppBillingV3Vendor(AbstractInAppBillingV3API api) {
+    this(api, null);
+  }
+
+  public InAppBillingV3Vendor(AbstractInAppBillingV3API api, @Nullable String publicKey64) {
+    if (api == null) {
+      throw new IllegalArgumentException("Null api");
     }
 
-    @Override
-    public void initialize(Context context, InitializationListener listener) {
-        if (context == null || listener == null) {
-            throw new IllegalArgumentException("Context or initialization listener is null");
-        }
+    this.api = api;
+    this.publicKey64 = publicKey64;
+    available = false;
+  }
 
-        initializationListener = listener;
+  @Override
+  public String id() {
+    return VENDOR_PACKAGE;
+  }
 
-        if (available()) {
-            listener.initialized();
-            return;
-        }
-
-        log("Initializing In-App billing v3...");
-        available = api.initialize(context, this, lifecycleListener, logger);
-
-        if (!available) {
-            initializationListener.unavailable();
-        }
+  @Override
+  public void initialize(Context context, InitializationListener listener) {
+    if (context == null || listener == null) {
+      throw new IllegalArgumentException("Context or initialization listener is null");
     }
 
-    @Override
-    public void dispose(Context context) {
-        if (context == null) {
-            throw new IllegalArgumentException("Given null context");
-        }
-        log("Disposing self...");
-        api.dispose(context);
-        available = false;
+    initializationListener = listener;
+
+    if (available()) {
+      listener.initialized();
+      return;
     }
 
-    @Override
-    public boolean available() {
-        return available && api.available() && canPurchaseAnything();
+    log("Initializing In-App billing v3...");
+    available = api.initialize(context, this, lifecycleListener, logger);
+
+    if (!available) {
+      initializationListener.unavailable();
+    }
+  }
+
+  @Override
+  public void dispose(Context context) {
+    if (context == null) {
+      throw new IllegalArgumentException("Given null context");
+    }
+    log("Disposing self...");
+    api.dispose(context);
+    available = false;
+  }
+
+  @Override
+  public boolean available() {
+    return available && api.available() && canPurchaseAnything();
+  }
+
+  int getRequestCode() {
+    return requestCode;
+  }
+
+  @Override
+  public boolean canPurchase(Product product) {
+    if (!canPurchaseAnything()) {
+      return false;
     }
 
-    int getRequestCode() {
-        return requestCode;
+    if (product.isSubscription() && !canSubscribe) {
+      return false;
     }
 
-    @Override
-    public boolean canPurchase(Product product) {
-        if (!canPurchaseAnything()) {
-            return false;
-        }
-
-        if (product.isSubscription() && !canSubscribe) {
-            return false;
-        }
-
-        if (!product.isSubscription() && !canPurchaseItems) {
-            return false;
-        }
-
-        // TODO: Maybe query inventory and match skus
-
-        return true;
+    if (!product.isSubscription() && !canPurchaseItems) {
+      return false;
     }
 
-    @Override
-    public void purchase(Activity activity, Product product, String developerPayload,
-                         PurchaseListener listener) {
-        if (activity == null || product == null || listener == null) {
-            throw new IllegalArgumentException("Activity, product, or listener is null");
-        }
+    // TODO: Maybe query inventory and match skus
 
-        throwIfUninitialized();
+    return true;
+  }
 
-        if (!canPurchase(product)) {
-            throw new IllegalArgumentException("Cannot purchase given product!" + product.toString());
-        }
+  @Override
+  public void purchase(Activity activity, Product product, String developerPayload,
+                       PurchaseListener listener) {
+    if (activity == null || product == null || listener == null) {
+      throw new IllegalArgumentException("Activity, product, or listener is null");
+    }
 
-        log("Constructing buy intent...");
-        final String type = product.isSubscription() ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
+    throwIfUninitialized();
+
+    if (!canPurchase(product)) {
+      throw new IllegalArgumentException("Cannot purchase given product!" + product.toString());
+    }
+
+    log("Constructing buy intent...");
+    final String type = product.isSubscription() ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
+    try {
+      if (developerPayload == null) {
+        this.developerPayload = UUID.randomUUID().toString();
+      } else {
+        this.developerPayload = developerPayload;
+      }
+
+      final Bundle buyBundle = api.getBuyIntent(product.sku(), type, developerPayload);
+      final int response = getResponseCode(buyBundle);
+      if (response != BILLING_RESPONSE_RESULT_OK) {
+        log("Couldn't purchase product! code:" + response);
+        listener.failure(product, purchaseError(response));
+        return;
+      }
+
+      final PendingIntent pendingIntent = buyBundle.getParcelable(RESPONSE_BUY_INTENT);
+      if (pendingIntent == null) {
+        log("Received no pending intent!");
+        listener.failure(product, purchaseError(response));
+        return;
+      }
+
+      log("Launching buy intent for " + product.sku());
+      this.purchaseListener = listener;
+      pendingProduct = product;
+      requestCode = new Random().nextInt(1024);
+      activity.startIntentSenderForResult(pendingIntent.getIntentSender(),
+          requestCode,
+          new Intent(), 0, 0, 0);
+    } catch (RemoteException | IntentSender.SendIntentException e) {
+      log("Failed to launch purchase!\n" + Log.getStackTraceString(e));
+      listener.failure(product, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
+    }
+  }
+
+  @Override
+  public void consume(Context context, Purchase purchase, ConsumeListener listener) {
+    if (context == null || purchase == null || listener == null) {
+      throw new IllegalArgumentException("Context, product, or listener is null");
+    }
+
+    throwIfUninitialized();
+
+    final Product product = purchase.product();
+    if (product.isSubscription()) {
+      throw new IllegalArgumentException("Cannot consume a subscription!");
+    }
+
+    try {
+      log("Consuming " + product.sku() + " " + purchase.token());
+      final int response = api.consumePurchase(purchase.token());
+      if (response == BILLING_RESPONSE_RESULT_OK) {
+        log("Successfully consumed purchase!");
+        listener.success(purchase);
+      } else {
+        log("Couldn't consume purchase! " + response);
+        listener.failure(purchase, consumeError(response));
+      }
+    } catch (RemoteException e) {
+      log("Couldn't consume purchase! " + Log.getStackTraceString(e));
+      listener.failure(purchase, consumeError(BILLING_RESPONSE_RESULT_ERROR));
+    }
+  }
+
+  @Override
+  public void getInventory(Context context, final Collection<String> inAppSkus, final Collection<String> subSkus,
+                           final InventoryListener listener) {
+    if (context == null || listener == null) {
+      throw new IllegalArgumentException("Context or listener is null");
+    }
+
+    throwIfUninitialized();
+
+    final Handler callThread = new Handler();
+    Runnable skuTask = new Runnable() {
+      @Override
+      public void run() {
+        // Convert the given collections to a list
+        final List<String> inappSkusList = inAppSkus == null ? null : new ArrayList<>(inAppSkus);
+        final List<String> subSkusList = subSkus == null ? null : new ArrayList<>(subSkus);
+
+        final Inventory inventory = new Inventory();
         try {
-            if (developerPayload == null) {
-                this.developerPayload = UUID.randomUUID().toString();
-            } else {
-                this.developerPayload = developerPayload;
-            }
+          log("Querying inventory...");
+          inventory.addPurchases(getPurchases(PRODUCT_TYPE_ITEM));
+          inventory.addPurchases(getPurchases(PRODUCT_TYPE_SUBSCRIPTION));
 
-            final Bundle buyBundle = api.getBuyIntent(product.sku(), type, developerPayload);
-            final int response = getResponseCode(buyBundle);
-            if (response != BILLING_RESPONSE_RESULT_OK) {
-                log("Couldn't purchase product! code:" + response);
-                listener.failure(product, purchaseError(response));
-                return;
-            }
+          if (inappSkusList != null && !inappSkusList.isEmpty()) {
+            inventory.addProducts(getProductsWithType(inappSkusList, PRODUCT_TYPE_ITEM));
+          }
 
-            final PendingIntent pendingIntent = buyBundle.getParcelable(RESPONSE_BUY_INTENT);
-            if (pendingIntent == null) {
-                log("Received no pending intent!");
-                listener.failure(product, purchaseError(response));
-                return;
-            }
+          if (subSkusList != null && !subSkusList.isEmpty()) {
+            inventory.addProducts(getProductsWithType(subSkusList, PRODUCT_TYPE_SUBSCRIPTION));
+          }
 
-            log("Launching buy intent for " + product.sku());
-            this.purchaseListener = listener;
-            pendingProduct = product;
-            requestCode = new Random().nextInt(1024);
-            activity.startIntentSenderForResult(pendingIntent.getIntentSender(),
-                    requestCode,
-                    new Intent(), 0, 0, 0);
-        } catch (RemoteException | IntentSender.SendIntentException e) {
-            log("Failed to launch purchase!\n" + Log.getStackTraceString(e));
-            listener.failure(product, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
-        }
-    }
-
-    @Override
-    public void consume(Context context, Purchase purchase, ConsumeListener listener) {
-        if (context == null || purchase == null || listener == null) {
-            throw new IllegalArgumentException("Context, product, or listener is null");
-        }
-
-        throwIfUninitialized();
-
-        final Product product = purchase.product();
-        if (product.isSubscription()) {
-            throw new IllegalArgumentException("Cannot consume a subscription!");
-        }
-
-        try {
-            log("Consuming " + product.sku() + " " + purchase.token());
-            final int response = api.consumePurchase(purchase.token());
-            if (response == BILLING_RESPONSE_RESULT_OK) {
-                log("Successfully consumed purchase!");
-                listener.success(purchase);
-            } else {
-                log("Couldn't consume purchase! " + response);
-                listener.failure(purchase, consumeError(response));
-            }
-        } catch (RemoteException e) {
-            log("Couldn't consume purchase! " + Log.getStackTraceString(e));
-            listener.failure(purchase, consumeError(BILLING_RESPONSE_RESULT_ERROR));
-        }
-    }
-
-    @Override
-    public void getInventory(Context context, final Collection<String> inAppSkus, final Collection<String> subSkus,
-                             final InventoryListener listener) {
-        if (context == null || listener == null) {
-            throw new IllegalArgumentException("Context or listener is null");
-        }
-
-        throwIfUninitialized();
-        final Handler caller = new Handler();
-        Runnable skuTask = new Runnable() {
+          callThread.post(new Runnable() {
             @Override
             public void run() {
-                // Convert the given collections to a list
-                final List<String> inappSkusList = inAppSkus == null ? null : new ArrayList<>(inAppSkus);
-                final List<String> subSkusList = subSkus == null ? null : new ArrayList<>(subSkus);
-
-                final Inventory inventory = new Inventory();
-                try {
-                    log("Querying inventory...");
-                    inventory.addPurchases(getPurchases(PRODUCT_TYPE_ITEM));
-                    inventory.addPurchases(getPurchases(PRODUCT_TYPE_SUBSCRIPTION));
-
-                    if (inappSkusList != null && !inappSkusList.isEmpty()) {
-                        inventory.addProducts(getProductsWithType(inappSkusList, PRODUCT_TYPE_ITEM));
-                    }
-
-                    if (subSkusList != null && !subSkusList.isEmpty()) {
-                        inventory.addProducts(getProductsWithType(subSkusList, PRODUCT_TYPE_SUBSCRIPTION));
-                    }
-
-                    caller.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.success(inventory);
-                        }
-                    });
-                } catch (RemoteException | ApiException e) {
-                    caller.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.failure(new Vendor.Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
-                        }
-                    });
-                } catch (JSONException e) {
-                    caller.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.failure(new Vendor.Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
-                        }
-                    });
-                }
+              listener.success(inventory);
             }
-        };
-
-        if (DISABLE_EXECUTOR) {
-            caller.post(skuTask);
-        } else {
-            executor.execute(skuTask);
-        }
-    }
-
-    @Override
-    public void getProductDetails(Context context, String sku, boolean isSubscription,
-                                  ProductDetailsListener listener) {
-        if (context == null || sku == null || listener == null) {
-            throw new IllegalArgumentException("Context or sku or listener is null");
-        }
-        throwIfUninitialized();
-        final String type = isSubscription ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
-        try {
-            final List<Product> productList = getProductsWithType(Collections.singletonList(sku), type);
-            if (productList.isEmpty()) {
-                listener.failure(new Vendor.Error(PRODUCT_DETAILS_NOT_FOUND, -1));
-                return;
-            }
-
-            listener.success(productList.get(0));
+          });
         } catch (RemoteException | ApiException e) {
-            listener.failure(new Vendor.Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
-        }
-    }
-
-    private List<InAppBillingPurchase> getPurchases(String type)
-            throws RemoteException, ApiException, JSONException {
-        throwIfUninitialized();
-        if (type.equals(PRODUCT_TYPE_ITEM)) {
-            log("Querying item purchases...");
-        } else {
-            log("Querying subscription purchases...");
-        }
-        String paginationToken = null;
-        final List<InAppBillingPurchase> purchaseList = new ArrayList<>();
-        do {
-            final Bundle purchases = api.getPurchases(type, paginationToken);
-
-            final int response = getResponseCode(purchases);
-            log("Got response: " + response);
-            if (response != BILLING_RESPONSE_RESULT_OK) {
-                throw new ApiException(response);
+          callThread.post(new Runnable() {
+            @Override
+            public void run() {
+              listener.failure(new Error(INVENTORY_QUERY_FAILURE, codeFromException(e)));
             }
-
-            if (!purchases.containsKey(RESPONSE_INAPP_ITEM_LIST)
-                    || !purchases.containsKey(RESPONSE_INAPP_PURCHASE_DATA_LIST)
-                    || !purchases.containsKey(RESPONSE_INAPP_SIGNATURE_LIST)) {
-                throw new ApiException(BILLING_RESPONSE_RESULT_ERROR);
+          });
+        } catch (JSONException e) {
+          callThread.post(new Runnable() {
+            @Override
+            public void run() {
+              listener.failure(new Error(INVENTORY_QUERY_MALFORMED_RESPONSE, -1));
             }
+          });
+        }
+      }
+    };
 
-            final List<String> purchasedSkus
-                    = purchases.getStringArrayList(RESPONSE_INAPP_ITEM_LIST);
-            final List<String> purchaseDataList
-                    = purchases.getStringArrayList(RESPONSE_INAPP_PURCHASE_DATA_LIST);
-            final List<String> signatureList
-                    = purchases.getStringArrayList(RESPONSE_INAPP_SIGNATURE_LIST);
-
-            if (purchasedSkus == null || purchaseDataList == null || signatureList == null) {
-                return Collections.emptyList();
-            }
-
-            final List<Product> purchasedProducts = getProductsWithType(purchasedSkus, type);
-
-            for (int i = 0; i < purchaseDataList.size(); ++i) {
-                final String purchaseData = purchaseDataList.get(i);
-                final String sku = purchasedSkus.get(i);
-                final String signature = signatureList.get(i);
-
-                Product product = null;
-                for (final Product maybeProduct : purchasedProducts) {
-                    if (sku.equals(maybeProduct.sku())) {
-                        product = maybeProduct;
-                        break;
-                    }
-                }
-
-                if (product == null) {
-                    // TODO: Should raise this as an error to the user
-                    continue;
-                }
-
-                log("Found purchase: " + sku);
-                if (!TextUtils.isEmpty(publicKey64)) {
-                    if (InAppBillingSecurity.verifySignature(publicKey64, purchaseData, signature)) {
-                        log("Purchase locally verified: " + sku);
-                    } else {
-                        log("Purchase not locally verified: " + sku);
-                        continue;
-                    }
-                }
-
-                purchaseList.add(InAppBillingPurchase.create(product, purchaseData, signature));
-            }
-
-            paginationToken = purchases.getString(INAPP_CONTINUATION_TOKEN);
-            if (paginationToken != null) {
-                log("Pagination token found, continuing on....");
-            }
-        } while (!TextUtils.isEmpty(paginationToken));
-
-        return Collections.unmodifiableList(purchaseList);
+    if (DISABLE_EXECUTOR) {
+      callThread.post(skuTask);
+    } else {
+      executor.execute(skuTask);
     }
+  }
 
-    private List<Product> getProductsWithType(List<String> skus, String type)
-            throws RemoteException, ApiException {
-        if (skus == null || TextUtils.isEmpty(type)) {
-            throw new IllegalArgumentException("Given skus are null or type is empty/null");
+  @Override
+  public void getProductDetails(Context context, String sku, boolean isSubscription,
+                                ProductDetailsListener listener) {
+    if (context == null || sku == null || listener == null) {
+      throw new IllegalArgumentException("Context or sku or listener is null");
+    }
+    throwIfUninitialized();
+    final String type = isSubscription ? PRODUCT_TYPE_SUBSCRIPTION : PRODUCT_TYPE_ITEM;
+    try {
+      final List<Product> productList = getProductsWithType(Collections.singletonList(sku), type);
+      if (productList.isEmpty()) {
+        listener.failure(new Error(PRODUCT_DETAILS_NOT_FOUND, -1));
+        return;
+      }
+
+      listener.success(productList.get(0));
+    } catch (RemoteException | ApiException e) {
+      listener.failure(new Error(PRODUCT_DETAILS_QUERY_FAILURE, codeFromException(e)));
+    }
+  }
+
+  private List<InAppBillingPurchase> getPurchases(String type)
+      throws RemoteException, ApiException, JSONException {
+    throwIfUninitialized();
+    if (type.equals(PRODUCT_TYPE_ITEM)) {
+      log("Querying item purchases...");
+    } else {
+      log("Querying subscription purchases...");
+    }
+    String paginationToken = null;
+    final List<InAppBillingPurchase> purchaseList = new ArrayList<>();
+    do {
+      final Bundle purchases = api.getPurchases(type, paginationToken);
+
+      final int response = getResponseCode(purchases);
+      log("Got response: " + response);
+      if (response != BILLING_RESPONSE_RESULT_OK) {
+        throw new ApiException(response);
+      }
+
+      if (!purchases.containsKey(RESPONSE_INAPP_ITEM_LIST)
+          || !purchases.containsKey(RESPONSE_INAPP_PURCHASE_DATA_LIST)
+          || !purchases.containsKey(RESPONSE_INAPP_SIGNATURE_LIST)) {
+        throw new ApiException(BILLING_RESPONSE_RESULT_ERROR);
+      }
+
+      final List<String> purchasedSkus
+          = purchases.getStringArrayList(RESPONSE_INAPP_ITEM_LIST);
+      final List<String> purchaseDataList
+          = purchases.getStringArrayList(RESPONSE_INAPP_PURCHASE_DATA_LIST);
+      final List<String> signatureList
+          = purchases.getStringArrayList(RESPONSE_INAPP_SIGNATURE_LIST);
+
+      if (purchasedSkus == null || purchaseDataList == null || signatureList == null) {
+        return Collections.emptyList();
+      }
+
+      final List<Product> purchasedProducts = getProductsWithType(purchasedSkus, type);
+
+      for (int i = 0; i < purchaseDataList.size(); ++i) {
+        final String purchaseData = purchaseDataList.get(i);
+        final String sku = purchasedSkus.get(i);
+        final String signature = signatureList.get(i);
+
+        Product product = null;
+        for (final Product maybeProduct : purchasedProducts) {
+          if (sku.equals(maybeProduct.sku())) {
+            product = maybeProduct;
+            break;
+          }
         }
 
-        throwIfUninitialized();
-        log("Retrieving sku details for " + skus.size() + " " + type + " skus");
-        if (!type.equals(PRODUCT_TYPE_ITEM) && !type.equals(PRODUCT_TYPE_SUBSCRIPTION)) {
-            throw new IllegalArgumentException("Invalid product type " + type);
+        if (product == null) {
+          // TODO: Should raise this as an error to the user
+          continue;
         }
 
-        final List<Product> products = new ArrayList<>();
-        for (int i = 0; i < skus.size(); i += 20) {
-            final ArrayList<String> page = new ArrayList<>(skus.subList(i, Math.min(skus.size(), i + 20)));
-            final Bundle skuQuery = new Bundle();
-            skuQuery.putStringArrayList(REQUEST_SKU_DETAILS_ITEM_LIST, page);
-
-            final Bundle skuDetails = api.getSkuDetails(type, skuQuery);
-            final int response = getResponseCode(skuDetails);
-            log("Got response: " + response);
-            if (skuDetails == null) {
-                continue;
-            }
-
-            if (response != BILLING_RESPONSE_RESULT_OK || !skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
-                throw new ApiException(response);
-            }
-
-            final ArrayList<String> detailsList
-                    = skuDetails.getStringArrayList(RESPONSE_GET_SKU_DETAILS_LIST);
-            if (detailsList == null) continue;
-
-            for (final String detail : detailsList) {
-                log("Parsing sku details: " + detail);
-                try {
-                    products.add(InAppBillingProduct.create(detail, type.equals(PRODUCT_TYPE_SUBSCRIPTION)));
-                } catch (JSONException e) {
-                    log("Couldn't parse sku: " + detail);
-                }
-            }
+        log("Found purchase: " + sku);
+        if (!TextUtils.isEmpty(publicKey64)) {
+          if (InAppBillingSecurity.verifySignature(publicKey64, purchaseData, signature)) {
+            log("Purchase locally verified: " + sku);
+          } else {
+            log("Purchase not locally verified: " + sku);
+            continue;
+          }
         }
 
-        return Collections.unmodifiableList(products);
+        purchaseList.add(InAppBillingPurchase.create(product, purchaseData, signature));
+      }
+
+      paginationToken = purchases.getString(INAPP_CONTINUATION_TOKEN);
+      if (paginationToken != null) {
+        log("Pagination token found, continuing on....");
+      }
+    } while (!TextUtils.isEmpty(paginationToken));
+
+    return Collections.unmodifiableList(purchaseList);
+  }
+
+  private List<Product> getProductsWithType(List<String> skus, String type)
+      throws RemoteException, ApiException {
+    if (skus == null || TextUtils.isEmpty(type)) {
+      throw new IllegalArgumentException("Given skus are null or type is empty/null");
     }
 
-    @Override
-    public void setLogger(@Nullable Logger logger) {
-        this.logger = logger;
+    throwIfUninitialized();
+    log("Retrieving sku details for " + skus.size() + " " + type + " skus");
+    if (!type.equals(PRODUCT_TYPE_ITEM) && !type.equals(PRODUCT_TYPE_SUBSCRIPTION)) {
+      throw new IllegalArgumentException("Invalid product type " + type);
     }
 
-    @Override
-    public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
-        log("onActivityResult " + resultCode);
-        if (this.requestCode != requestCode) {
-            return false;
+    final List<Product> products = new ArrayList<>();
+    for (int i = 0; i < skus.size(); i += 20) {
+      final ArrayList<String> page = new ArrayList<>(skus.subList(i, Math.min(skus.size(), i + 20)));
+      final Bundle skuQuery = new Bundle();
+      skuQuery.putStringArrayList(REQUEST_SKU_DETAILS_ITEM_LIST, page);
+
+      final Bundle skuDetails = api.getSkuDetails(type, skuQuery);
+      final int response = getResponseCode(skuDetails);
+      log("Got response: " + response);
+      if (skuDetails == null) {
+        continue;
+      }
+
+      if (response != BILLING_RESPONSE_RESULT_OK || !skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
+        throw new ApiException(response);
+      }
+
+      final ArrayList<String> detailsList
+          = skuDetails.getStringArrayList(RESPONSE_GET_SKU_DETAILS_LIST);
+      if (detailsList == null) continue;
+
+      for (final String detail : detailsList) {
+        log("Parsing sku details: " + detail);
+        try {
+          products.add(InAppBillingProduct.create(detail, type.equals(PRODUCT_TYPE_SUBSCRIPTION)));
+        } catch (JSONException e) {
+          log("Couldn't parse sku: " + detail);
+        }
+      }
+    }
+
+    return Collections.unmodifiableList(products);
+  }
+
+  @Override
+  public void setLogger(@Nullable Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+    log("onActivityResult " + resultCode);
+    if (this.requestCode != requestCode) {
+      return false;
+    }
+
+    if (data == null) {
+      purchaseListener.failure(pendingProduct, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
+      return true;
+    }
+
+    final int responseCode = getResponseCode(data);
+    if (resultCode == Activity.RESULT_OK && responseCode == BILLING_RESPONSE_RESULT_OK) {
+      try {
+        final InAppBillingPurchase purchase = InAppBillingPurchase.create(pendingProduct, data);
+        if (!purchase.developerPayload().equals(developerPayload)) {
+          log("Developer payload mismatch!");
+          purchaseListener.failure(pendingProduct,
+              new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                  BILLING_RESPONSE_RESULT_ERROR));
+          return true;
         }
 
-        if (data == null) {
-            purchaseListener.failure(pendingProduct, purchaseError(BILLING_RESPONSE_RESULT_ERROR));
-            return true;
+        if (!TextUtils.isEmpty(publicKey64)
+            && !InAppBillingSecurity.verifySignature(publicKey64, purchase.receipt(), purchase.dataSignature())) {
+          log("Local signature check failed!");
+          purchaseListener.failure(pendingProduct,
+              new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                  BILLING_RESPONSE_RESULT_ERROR));
+          return true;
         }
 
-        final int responseCode = getResponseCode(data);
-        if (resultCode == Activity.RESULT_OK && responseCode == BILLING_RESPONSE_RESULT_OK) {
-            try {
-                final InAppBillingPurchase purchase = InAppBillingPurchase.create(pendingProduct, data);
-                if (!purchase.developerPayload().equals(developerPayload)) {
-                    log("Developer payload mismatch!");
-                    purchaseListener.failure(pendingProduct,
-                            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                                    BILLING_RESPONSE_RESULT_ERROR));
-                    return true;
-                }
-
-                if (!TextUtils.isEmpty(publicKey64)
-                        && !InAppBillingSecurity.verifySignature(publicKey64, purchase.receipt(), purchase.dataSignature())) {
-                    log("Local signature check failed!");
-                    purchaseListener.failure(pendingProduct,
-                            new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                                    BILLING_RESPONSE_RESULT_ERROR));
-                    return true;
-                }
-
-                log("Successful purchase of " + pendingProduct.sku() + "!");
-                purchaseListener.success(purchase);
-                developerPayload = null;
-            } catch (JSONException e) {
-                purchaseListener.failure(pendingProduct,
-                        new Vendor.Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
-                                BILLING_RESPONSE_RESULT_ERROR));
-            }
-        } else if (resultCode == Activity.RESULT_OK) {
-            log("CashierPurchase failed! " + responseCode);
-            purchaseListener.failure(pendingProduct, purchaseError(responseCode));
-        } else {
-            log("CashierPurchase canceled! " + responseCode);
-            purchaseListener.failure(pendingProduct, purchaseError(responseCode));
-        }
-
-        return true;
+        log("Successful purchase of " + pendingProduct.sku() + "!");
+        purchaseListener.success(purchase);
+        developerPayload = null;
+      } catch (JSONException e) {
+        purchaseListener.failure(pendingProduct,
+            new Error(PURCHASE_SUCCESS_RESULT_MALFORMED,
+                BILLING_RESPONSE_RESULT_ERROR));
+      }
+    } else if (resultCode == Activity.RESULT_OK) {
+      log("CashierPurchase failed! " + responseCode);
+      purchaseListener.failure(pendingProduct, purchaseError(responseCode));
+    } else {
+      log("CashierPurchase canceled! " + responseCode);
+      purchaseListener.failure(pendingProduct, purchaseError(responseCode));
     }
 
-    @Override
-    public Product getProductFrom(JSONObject json) throws JSONException {
-        final Product product = Product.create(json);
-        if (!product.vendorId().equals(VENDOR_PACKAGE)) {
-            throw new IllegalArgumentException("This product does not belong to Google Play");
-        }
+    return true;
+  }
 
-        return product;
+  @Override
+  public Product getProductFrom(JSONObject json) throws JSONException {
+    final Product product = Product.create(json);
+    if (!product.vendorId().equals(VENDOR_PACKAGE)) {
+      throw new IllegalArgumentException("This product does not belong to Google Play");
     }
 
-    @Override
-    public Purchase getPurchaseFrom(JSONObject json) throws JSONException {
-        final InAppBillingPurchase purchase = InAppBillingPurchase.create(json);
-        if (!purchase.product().vendorId().equals(VENDOR_PACKAGE)) {
-            throw new IllegalArgumentException("This purchase does not belong to Google Play");
-        }
+    return product;
+  }
 
-        return purchase;
+  @Override
+  public Purchase getPurchaseFrom(JSONObject json) throws JSONException {
+    final InAppBillingPurchase purchase = InAppBillingPurchase.create(json);
+    if (!purchase.product().vendorId().equals(VENDOR_PACKAGE)) {
+      throw new IllegalArgumentException("This purchase does not belong to Google Play");
     }
 
-    private void throwIfUninitialized() {
-        if (!api.available()) {
-            throw new IllegalStateException("Trying to purchase without initializing first!");
-        }
+    return purchase;
+  }
+
+  private void throwIfUninitialized() {
+    if (!api.available()) {
+      throw new IllegalStateException("Trying to purchase without initializing first!");
+    }
+  }
+
+  private boolean canPurchaseAnything() {
+    return canPurchaseItems || canSubscribe;
+  }
+
+  private void logAndDisable(String message) {
+    log(message);
+    available = false;
+  }
+
+  private int getResponseCode(Intent intent) {
+    final Bundle extras = intent.getExtras();
+    return getResponseCode(extras);
+  }
+
+  private int getResponseCode(Bundle bundle) {
+    if (bundle == null) {
+      log("Null response code from bundle, assuming OK (known issue)");
+      return BILLING_RESPONSE_RESULT_OK;
     }
 
-    private boolean canPurchaseAnything() {
-        return canPurchaseItems || canSubscribe;
+    final Object o = bundle.get(RESPONSE_CODE);
+    if (o == null) {
+      log("Null response code from bundle, assuming OK (known issue)");
+      return BILLING_RESPONSE_RESULT_OK;
+    } else if (o instanceof Integer) {
+      return (Integer) o;
+    } else if (o instanceof Long) {
+      return ((Long) o).intValue();
+    } else {
+      final String message = "Unexpected type for bundle response code. " + o.getClass().getName();
+      log(message);
+      throw new RuntimeException(message);
+    }
+  }
+
+  private int codeFromException(Exception e) {
+    if (e instanceof ApiException) {
+      return ((ApiException) e).code;
     }
 
-    private void logAndDisable(String message) {
-        log(message);
-        available = false;
+    return -1;
+  }
+
+  private Error purchaseError(int response) {
+    final int code;
+    switch (response) {
+      case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
+      case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+        code = PURCHASE_UNAVAILABLE;
+        break;
+      case BILLING_RESPONSE_RESULT_USER_CANCELED:
+        code = PURCHASE_CANCELED;
+        break;
+      case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
+        code = PURCHASE_ALREADY_OWNED;
+        break;
+      case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+        code = PURCHASE_NOT_OWNED;
+        break;
+      case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+      case BILLING_RESPONSE_RESULT_ERROR:
+      default:
+        code = PURCHASE_FAILURE;
+        break;
     }
 
-    private int getResponseCode(Intent intent) {
-        final Bundle extras = intent.getExtras();
-        return getResponseCode(extras);
+    return new Error(code, response);
+  }
+
+  private Error consumeError(int response) {
+    final int code;
+    switch (response) {
+      case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
+      case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+        code = CONSUME_UNAVAILABLE;
+        break;
+      case BILLING_RESPONSE_RESULT_USER_CANCELED:
+        code = CONSUME_CANCELED;
+        break;
+      case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+        code = CONSUME_NOT_OWNED;
+        break;
+      case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+      case BILLING_RESPONSE_RESULT_ERROR:
+      default:
+        code = CONSUME_FAILURE;
+        break;
     }
 
-    private int getResponseCode(Bundle bundle) {
-        if (bundle == null) {
-            log("Null response code from bundle, assuming OK (known issue)");
-            return BILLING_RESPONSE_RESULT_OK;
-        }
+    return new Error(code, response);
+  }
 
-        final Object o = bundle.get(RESPONSE_CODE);
-        if (o == null) {
-            log("Null response code from bundle, assuming OK (known issue)");
-            return BILLING_RESPONSE_RESULT_OK;
-        } else if (o instanceof Integer) {
-            return (Integer) o;
-        } else if (o instanceof Long) {
-            return ((Long) o).intValue();
-        } else {
-            final String message = "Unexpected type for bundle response code. " + o.getClass().getName();
-            log(message);
-            throw new RuntimeException(message);
-        }
+  private void log(String message) {
+    if (logger == null) return;
+    logger.i("InAppBillingV3Vendor", message);
+  }
+
+  private class ApiException extends Exception {
+    private final int code;
+
+    public ApiException(final int code) {
+      super("Received Billing API response " + code);
+      this.code = code;
     }
 
-    private int codeFromException(Exception e) {
-        if (e instanceof ApiException) {
-            return ((ApiException) e).code;
-        }
-
-        return -1;
+    public int code() {
+      return code;
     }
-
-    private Vendor.Error purchaseError(int response) {
-        final int code;
-        switch (response) {
-            case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
-            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-                code = PURCHASE_UNAVAILABLE;
-                break;
-            case BILLING_RESPONSE_RESULT_USER_CANCELED:
-                code = PURCHASE_CANCELED;
-                break;
-            case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
-                code = PURCHASE_ALREADY_OWNED;
-                break;
-            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-                code = PURCHASE_NOT_OWNED;
-                break;
-            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-            case BILLING_RESPONSE_RESULT_ERROR:
-            default:
-                code = PURCHASE_FAILURE;
-                break;
-        }
-
-        return new Vendor.Error(code, response);
-    }
-
-    private Vendor.Error consumeError(int response) {
-        final int code;
-        switch (response) {
-            case BILLING_RESPONSE_RESULT_BILLING_UNAVAILABLE:
-            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-                code = CONSUME_UNAVAILABLE;
-                break;
-            case BILLING_RESPONSE_RESULT_USER_CANCELED:
-                code = CONSUME_CANCELED;
-                break;
-            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-                code = CONSUME_NOT_OWNED;
-                break;
-            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-            case BILLING_RESPONSE_RESULT_ERROR:
-            default:
-                code = CONSUME_FAILURE;
-                break;
-        }
-
-        return new Vendor.Error(code, response);
-    }
-
-    private void log(String message) {
-        if (logger == null) return;
-        logger.i("InAppBillingV3Vendor", message);
-    }
-
-    private class ApiException extends Exception {
-        private final int code;
-
-        public ApiException(final int code) {
-            super("Received Billing API response " + code);
-            this.code = code;
-        }
-
-        public int code() {
-            return code;
-        }
-    }
+  }
 }

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -25,6 +25,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.RemoteException;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 

--- a/cashier-iab/src/test/java/com/getkeepsafe/cashier/iab/InAppBillingV3VendorTest.java
+++ b/cashier-iab/src/test/java/com/getkeepsafe/cashier/iab/InAppBillingV3VendorTest.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
@@ -54,8 +53,8 @@ import static com.getkeepsafe.cashier.iab.InAppBillingConstants.RESPONSE_INAPP_S
 import static com.getkeepsafe.cashier.iab.InAppBillingConstants.RESPONSE_INAPP_SIGNATURE_LIST;
 import static com.getkeepsafe.cashier.iab.InAppBillingConstants.VENDOR_PACKAGE;
 import static com.getkeepsafe.cashier.iab.InAppBillingTestData.IN_APP_BILLING_PRODUCT_VALID_PRODUCT_JSON;
-import static com.getkeepsafe.cashier.iab.InAppBillingTestData.TEST_PUBLIC_KEY;
 import static com.getkeepsafe.cashier.iab.InAppBillingTestData.TEST_INVALID_PUBLIC_KEY;
+import static com.getkeepsafe.cashier.iab.InAppBillingTestData.TEST_PUBLIC_KEY;
 import static com.getkeepsafe.cashier.iab.InAppBillingTestData.VALID_ONE_TIME_PURCHASE_JSON;
 import static com.getkeepsafe.cashier.iab.InAppBillingTestData.VALID_PURCHASE_RECEIPT_JSON;
 import static com.getkeepsafe.cashier.iab.InAppBillingTestData.VALID_SUBSCRIPTION_PURCHASE_JSON;
@@ -65,7 +64,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
@@ -88,6 +86,7 @@ public class InAppBillingV3VendorTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        InAppBillingV3Vendor.DISABLE_EXECUTOR = true;
     }
 
     @Test

--- a/cashier-sample/build.gradle
+++ b/cashier-sample/build.gradle
@@ -20,10 +20,9 @@ android {
 }
 
 dependencies {
-  compile project(':cashier')
-  compile project(':cashier-iab')
-  debugCompile project(':cashier-iab-debug')
-  releaseCompile project(':cashier-iab-debug-no-op')
+  implementation project(':cashier-iab')
+  debugImplementation project(':cashier-iab-debug')
+  releaseImplementation project(':cashier-iab-debug-no-op')
 
-  compile deps.appCompat
+  implementation deps.appCompat
 }

--- a/cashier/build.gradle
+++ b/cashier/build.gradle
@@ -28,15 +28,15 @@ android {
 }
 
 dependencies {
-  provided deps.autoValue
-  provided deps.supportAnnotations
+  compileOnly deps.autoValue
+  compileOnly deps.supportAnnotations
   annotationProcessor deps.autoValue
   annotationProcessor deps.autoParcel
 
-  testCompile deps.robolectric
-  testCompile deps.junit
-  testCompile deps.mockito
-  testCompile deps.truth
+  testImplementation deps.robolectric
+  testImplementation deps.junit
+  testImplementation deps.mockito
+  testImplementation deps.truth
 }
 
 apply from: rootProject.file('javadoc.gradle')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext {
       compileSdk : 27,
       minSdk     : 9,
       buildTools : '27.0.3',
-      versionName: '0.2.3'
+      versionName: '0.2.4'
   ]
 
   final supportLibraryVersion = '27.0.2'

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,12 +1,12 @@
 ext {
   versions = [
-      compileSdk : 25,
+      compileSdk : 27,
       minSdk     : 9,
-      buildTools : '25.0.2',
+      buildTools : '27.0.3',
       versionName: '0.2.3'
   ]
 
-  final supportLibraryVersion = '25.2.0'
+  final supportLibraryVersion = '27.0.2'
 
   deps = [
       autoValue         : 'com.google.auto.value:auto-value:1.3',

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext {
       compileSdk : 27,
       minSdk     : 9,
       buildTools : '27.0.3',
-      versionName: '0.2.4'
+      versionName: '0.2.5'
   ]
 
   final supportLibraryVersion = '27.0.2'


### PR DESCRIPTION
```InAppBillingV3Vendor#getInventory()``` which internally calls ```InAppBillingV3Api#getSkuDetails()```  can get called on the main that could cause an ANR.  We move it to a background thread and post the result callback to the caller's thread.

Stacktrace
```

  at android.os.BinderProxy.transact (BinderProxy.java:761)
  at com.android.vending.billing.IInAppBillingService$Stub$Proxy.getSkuDetails (IInAppBillingService.java:241)
  at com.getkeepsafe.cashier.iab.InAppBillingV3API.getSkuDetails (InAppBillingV3API.java:150)
  at com.getkeepsafe.cashier.iab.InAppBillingV3Vendor.getProductsWithType (InAppBillingV3Vendor.java:447)
  at com.getkeepsafe.cashier.iab.InAppBillingV3Vendor.getPurchases (InAppBillingV3Vendor.java:387)
  at com.getkeepsafe.cashier.iab.InAppBillingV3Vendor.getInventory (InAppBillingV3Vendor.java:312)
  at com.getkeepsafe.cashier.Cashier$4.initialized (Cashier.java:272)
  at com.getkeepsafe.cashier.iab.InAppBillingV3Vendor$1.initialized (InAppBillingV3Vendor.java:118)
  at com.getkeepsafe.cashier.iab.InAppBillingV3API$1.onServiceConnected (InAppBillingV3API.java:64)
```