### PR TITLE
Inventory query crash fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.3
+  - Fixed inventory query uncaught exception
+
 ## 0.3.0
   - Google Play Billing lib implementation - GooglePlayBillingVendor
   - Google Play Billing implementation unit tests

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
@@ -93,6 +93,11 @@ class InventoryQuery {
         threading.runInBackground(new Runnable() {
             @Override
             public void run() {
+                if (!api.available()) {
+                    listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_UNAVAILABLE, -1));
+                    return;
+                }
+
                 inappSkuDetails = null;
                 subsSkuDetails = null;
                 Set<String> inappSkusToQuery = new HashSet<>();

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
@@ -93,81 +93,86 @@ class InventoryQuery {
         threading.runInBackground(new Runnable() {
             @Override
             public void run() {
-                if (!api.available()) {
+                try {
+                    if (!api.available()) {
+                        listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_UNAVAILABLE, -1));
+                        return;
+                    }
+
+                    inappSkuDetails = null;
+                    subsSkuDetails = null;
+                    Set<String> inappSkusToQuery = new HashSet<>();
+                    Set<String> subSkusToQuery = new HashSet<>();
+                    boolean subscriptionsSupported = api.isBillingSupported(BillingClient.SkuType.SUBS) == BillingClient.BillingResponse.OK;
+
+                    if (inappSkus != null) {
+                        inappSkusToQuery.addAll(inappSkus);
+                    }
+                    if (subSkus != null) {
+                        subSkusToQuery.addAll(subSkus);
+                    }
+
+                    // Get purchases of both types
+                    List<com.android.billingclient.api.Purchase> inappPurchases = api.getPurchases(BillingClient.SkuType.INAPP);
+                    List<com.android.billingclient.api.Purchase> subPurchases = subscriptionsSupported ? api.getPurchases(BillingClient.SkuType.SUBS)
+                            : new ArrayList<com.android.billingclient.api.Purchase>();
+
+                    if (inappPurchases == null || subPurchases == null) {
+                        // If any of two getPurchases call didn't return result, return error
+                        listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_FAILURE, -1));
+                        return;
+                    }
+
+                    purchases = new ArrayList<>();
+                    purchases.addAll(inappPurchases);
+                    purchases.addAll(subPurchases);
+
+                    // Add all inapp purchases skus to skus to be queried list
+                    for (com.android.billingclient.api.Purchase inappPurchase : inappPurchases) {
+                        inappSkusToQuery.add(inappPurchase.getSku());
+                    }
+                    // Add all subscription purchases skus to skus to be queried list
+                    for (com.android.billingclient.api.Purchase subPurchase : subPurchases) {
+                        subSkusToQuery.add(subPurchase.getSku());
+                    }
+
+                    if (inappSkusToQuery.size() > 0) {
+                        // Perform async sku details query
+                        api.getSkuDetails(BillingClient.SkuType.INAPP, new ArrayList<String>(inappSkusToQuery), new SkuDetailsResponseListener() {
+                            @Override
+                            public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
+                                inappSkuDetails = skuDetailsList != null ? skuDetailsList : new ArrayList<SkuDetails>();
+                                inappResponseCode = responseCode;
+                                // Check if other async operation finished
+                                notifyIfReady();
+                            }
+                        });
+                    } else {
+                        inappSkuDetails = Collections.emptyList();
+                    }
+
+                    if (subSkusToQuery.size() > 0 && subscriptionsSupported) {
+                        // Perform async sku details query
+                        api.getSkuDetails(BillingClient.SkuType.SUBS, new ArrayList<String>(subSkusToQuery), new SkuDetailsResponseListener() {
+                            @Override
+                            public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
+                                subsSkuDetails = skuDetailsList != null ? skuDetailsList : new ArrayList<SkuDetails>();
+                                subsResponseCode = responseCode;
+                                // Check if other async operation finished
+                                notifyIfReady();
+                            }
+                        });
+                    } else {
+                        subsSkuDetails = Collections.emptyList();
+                    }
+
+                    // Check if result may be delivered.
+                    // Covers case with empty skus and purchase lists
+                    notifyIfReady();
+
+                } catch (Exception e) {
                     listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_UNAVAILABLE, -1));
-                    return;
                 }
-
-                inappSkuDetails = null;
-                subsSkuDetails = null;
-                Set<String> inappSkusToQuery = new HashSet<>();
-                Set<String> subSkusToQuery = new HashSet<>();
-                boolean subscriptionsSupported = api.isBillingSupported(BillingClient.SkuType.SUBS) == BillingClient.BillingResponse.OK;
-
-                if (inappSkus != null) {
-                    inappSkusToQuery.addAll(inappSkus);
-                }
-                if (subSkus != null) {
-                    subSkusToQuery.addAll(subSkus);
-                }
-
-                // Get purchases of both types
-                List<com.android.billingclient.api.Purchase> inappPurchases = api.getPurchases(BillingClient.SkuType.INAPP);
-                List<com.android.billingclient.api.Purchase> subPurchases = subscriptionsSupported ? api.getPurchases(BillingClient.SkuType.SUBS)
-                                : new ArrayList<com.android.billingclient.api.Purchase>();
-
-                if (inappPurchases == null || subPurchases == null) {
-                    // If any of two getPurchases call didn't return result, return error
-                    listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_FAILURE, -1));
-                    return;
-                }
-
-                purchases = new ArrayList<>();
-                purchases.addAll(inappPurchases);
-                purchases.addAll(subPurchases);
-
-                // Add all inapp purchases skus to skus to be queried list
-                for (com.android.billingclient.api.Purchase inappPurchase : inappPurchases) {
-                    inappSkusToQuery.add(inappPurchase.getSku());
-                }
-                // Add all subscription purchases skus to skus to be queried list
-                for (com.android.billingclient.api.Purchase subPurchase : subPurchases) {
-                    subSkusToQuery.add(subPurchase.getSku());
-                }
-
-                if (inappSkusToQuery.size() > 0) {
-                    // Perform async sku details query
-                    api.getSkuDetails(BillingClient.SkuType.INAPP, new ArrayList<String>(inappSkusToQuery), new SkuDetailsResponseListener() {
-                        @Override
-                        public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
-                            inappSkuDetails = skuDetailsList != null ? skuDetailsList : new ArrayList<SkuDetails>();
-                            inappResponseCode = responseCode;
-                            // Check if other async operation finished
-                            notifyIfReady();
-                        }
-                    });
-                } else {
-                    inappSkuDetails = Collections.emptyList();
-                }
-
-                if (subSkusToQuery.size() > 0 && subscriptionsSupported) {
-                    // Perform async sku details query
-                    api.getSkuDetails(BillingClient.SkuType.SUBS, new ArrayList<String>(subSkusToQuery), new SkuDetailsResponseListener() {
-                        @Override
-                        public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
-                            subsSkuDetails = skuDetailsList != null ? skuDetailsList : new ArrayList<SkuDetails>();
-                            subsResponseCode = responseCode;
-                            // Check if other async operation finished
-                            notifyIfReady();
-                        }
-                    });
-                } else {
-                    subsSkuDetails = Collections.emptyList();
-                }
-
-                // Check if result may be delivered.
-                // Covers case with empty skus and purchase lists
-                notifyIfReady();
             }
         });
     }

--- a/cashier-google-play-billing/src/test/java/com/getkeepsafe/cashier/billing/InventoryQueryTest.java
+++ b/cashier-google-play-billing/src/test/java/com/getkeepsafe/cashier/billing/InventoryQueryTest.java
@@ -41,6 +41,7 @@ public class InventoryQueryTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
+        when(api.available()).thenReturn(true);
         when(api.getPurchases()).thenReturn(new ArrayList<Purchase>());
         when(api.getPurchases(anyString())).thenReturn(new ArrayList<Purchase>());
 
@@ -129,6 +130,22 @@ public class InventoryQueryTest {
     @Test
     public void returns_error_when_subs_sku_details_call_fails() {
         TestHelper.mockSkuDetailsError(api, BillingClient.SkuType.SUBS);
+
+        InventoryListener listener = mock(InventoryListener.class);
+        InventoryQuery.execute(
+                TestHelper.mockThreading(),
+                api,
+                listener,
+                TestData.allInAppSkus,
+                TestData.allSubSkus
+        );
+
+        verify(listener).failure(any(Vendor.Error.class));
+    }
+
+    @Test
+    public void returns_error_when_billing_not_available() {
+        TestHelper.mockApiUnavailable(api);
 
         InventoryListener listener = mock(InventoryListener.class);
         InventoryQuery.execute(

--- a/cashier-google-play-billing/src/test/java/com/getkeepsafe/cashier/billing/TestHelper.java
+++ b/cashier-google-play-billing/src/test/java/com/getkeepsafe/cashier/billing/TestHelper.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
@@ -73,6 +74,23 @@ class TestHelper {
                 eq(type),
                 Mockito.<String>anyList(),
                 any(SkuDetailsResponseListener.class));
+    }
+
+    static void mockApiUnavailable(AbstractGooglePlayBillingApi api) {
+        doAnswer(
+                new Answer() {
+                    @Override
+                    public Object answer(InvocationOnMock invocation) throws Throwable {
+                        throw new IllegalStateException("Billing client is not available");
+                    }
+                }
+        ).when(api).getSkuDetails(
+                anyString(),
+                Mockito.<String>anyList(),
+                any(SkuDetailsResponseListener.class));
+
+        when(api.available()).thenReturn(false);
+        when(api.getPurchases(anyString())).thenThrow(new IllegalStateException("Billing client is not available"));
     }
 
     static void mockPurchases(AbstractGooglePlayBillingApi api, final List<Product> products) {

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext {
             compileSdk : 28,
             minSdk     : 9,
             buildTools : '28.0.3',
-            versionName: '0.3.2'
+            versionName: '0.3.3'
     ]
 
     final supportLibraryVersion = '28.0.0'

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext {
             compileSdk : 28,
             minSdk     : 9,
             buildTools : '28.0.3',
-            versionName: '0.3.3'
+            versionName: '0.3.4'
     ]
 
     final supportLibraryVersion = '28.0.0'


### PR DESCRIPTION
Fixed uncaught exception thrown from InventoryQuery when Google Play Billing api is not available. When api is unavailable, failure is called on listener.

Note: this PR is over no-aidl branch we created to build special version of iab module that can be used with new billing api at the same time. Before merge should be cherry-picked to emarc/google-play-billing branch.