### PR TITLE
Improved error reporting, migration to Jetpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.6
+  - Improved error reporting, migration to Jetpack
+
 ## 0.3.5
   - Fixed inventory query uncaught exception
 

--- a/cashier-google-play-billing-debug/src/main/java/com/getkeepsafe/cashier/billing/debug/FakeGooglePlayBillingApi.java
+++ b/cashier-google-play-billing-debug/src/main/java/com/getkeepsafe/cashier/billing/debug/FakeGooglePlayBillingApi.java
@@ -4,9 +4,10 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.ConsumeResponseListener;

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/AbstractGooglePlayBillingApi.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/AbstractGooglePlayBillingApi.java
@@ -18,8 +18,9 @@ package com.getkeepsafe.cashier.billing;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.billingclient.api.BillingClient.SkuType;
 import com.android.billingclient.api.ConsumeResponseListener;

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/GooglePlayBillingApi.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/GooglePlayBillingApi.java
@@ -20,10 +20,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
 import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClient.BillingResponse;
@@ -158,13 +159,19 @@ public final class GooglePlayBillingApi extends AbstractGooglePlayBillingApi imp
                 new SkuDetailsResponseListener() {
                     @Override
                     public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
-                        if (skuDetailsList.size() > 0) {
-                            BillingFlowParams billingFlowParams = BillingFlowParams.newBuilder()
-                                    .setSkuDetails(skuDetailsList.get(0))
-                                    .build();
+                        try {
+                            if (responseCode == BillingResponse.OK && skuDetailsList.size() > 0) {
+                                BillingFlowParams billingFlowParams = BillingFlowParams.newBuilder()
+                                        .setSkuDetails(skuDetailsList.get(0))
+                                        .build();
 
-                            // This will call the {@link PurchasesUpdatedListener} specified in {@link #initialize}
-                            billing.launchBillingFlow(activity, billingFlowParams);
+                                // This will call the {@link PurchasesUpdatedListener} specified in {@link #initialize}
+                                billing.launchBillingFlow(activity, billingFlowParams);
+                            } else {
+                                vendor.onPurchasesUpdated(BillingResponse.ERROR, null);
+                            }
+                        } catch (Exception e) {
+                            vendor.onPurchasesUpdated(BillingResponse.ERROR, null);
                         }
                     }
                 }

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/GooglePlayBillingVendor.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/GooglePlayBillingVendor.java
@@ -19,10 +19,11 @@ package com.getkeepsafe.cashier.billing;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.billingclient.api.BillingClient.BillingResponse;
 import com.android.billingclient.api.BillingClient.SkuType;
@@ -229,7 +230,12 @@ public final class GooglePlayBillingVendor implements Vendor, PurchasesUpdatedLi
         this.purchaseListener = listener;
         this.pendingProduct = product;
         logSafely("Launching Google Play Billing flow for " + product.sku());
-        api.launchBillingFlow(activity, product.sku(), product.isSubscription() ? SkuType.SUBS : SkuType.INAPP);
+        try {
+            api.launchBillingFlow(activity, product.sku(), product.isSubscription() ? SkuType.SUBS : SkuType.INAPP);
+        } catch (Exception e) {
+            clearPendingPurchase();
+            throw e;
+        }
     }
 
     @Override

--- a/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
+++ b/cashier-google-play-billing/src/main/java/com/getkeepsafe/cashier/billing/InventoryQuery.java
@@ -1,7 +1,7 @@
 package com.getkeepsafe.cashier.billing;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.SkuDetails;

--- a/cashier-iab-debug/src/main/java/com/getkeepsafe/cashier/iab/debug/FakeInAppBillingV3Api.java
+++ b/cashier-iab-debug/src/main/java/com/getkeepsafe/cashier/iab/debug/FakeInAppBillingV3Api.java
@@ -19,7 +19,8 @@ package com.getkeepsafe.cashier.iab.debug;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.RemoteException;
-import android.support.annotation.VisibleForTesting;
+
+import androidx.annotation.VisibleForTesting;
 
 import com.getkeepsafe.cashier.Product;
 import com.getkeepsafe.cashier.iab.AbstractInAppBillingV3API;

--- a/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
+++ b/cashier-iab/src/main/java/com/getkeepsafe/cashier/iab/InAppBillingV3Vendor.java
@@ -23,9 +23,10 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
 import android.os.RemoteException;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.Nullable;
 
 import com.getkeepsafe.cashier.ConsumeListener;
 import com.getkeepsafe.cashier.Inventory;

--- a/cashier-sample-google-play-billing/build.gradle
+++ b/cashier-sample-google-play-billing/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'com.getkeepsafe.cashier:cashier-google-play-billing:0.3.5'
     implementation 'com.getkeepsafe.cashier:cashier-google-play-billing-debug:0.3.5'
 
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
 
     implementation deps.appCompat
 }

--- a/cashier-sample-google-play-billing/src/main/java/com/getkeepsafe/cashier/sample/googleplaybilling/ItemsAdapter.java
+++ b/cashier-sample-google-play-billing/src/main/java/com/getkeepsafe/cashier/sample/googleplaybilling/ItemsAdapter.java
@@ -1,13 +1,14 @@
 package com.getkeepsafe.cashier.sample.googleplaybilling;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.getkeepsafe.cashier.sample.googleplaybilling.ItemsAdapter.ItemViewHolder;
 

--- a/cashier-sample-google-play-billing/src/main/java/com/getkeepsafe/cashier/sample/googleplaybilling/MainActivity.java
+++ b/cashier-sample-google-play-billing/src/main/java/com/getkeepsafe/cashier/sample/googleplaybilling/MainActivity.java
@@ -18,14 +18,15 @@ package com.getkeepsafe.cashier.sample.googleplaybilling;
 
 import android.app.ProgressDialog;
 import android.os.Bundle;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.Switch;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.getkeepsafe.cashier.Cashier;
 import com.getkeepsafe.cashier.ConsumeListener;

--- a/cashier-sample-iab/src/main/java/com/getkeepsafe/cashier/sample/MainActivity.java
+++ b/cashier-sample-iab/src/main/java/com/getkeepsafe/cashier/sample/MainActivity.java
@@ -18,7 +18,6 @@ package com.getkeepsafe.cashier.sample;
 
 import android.app.ProgressDialog;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
@@ -27,6 +26,8 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.getkeepsafe.cashier.Cashier;
 import com.getkeepsafe.cashier.ConsumeListener;

--- a/cashier/src/main/java/com/getkeepsafe/cashier/Cashier.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/Cashier.java
@@ -20,9 +20,10 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Looper;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
+
+import androidx.annotation.Nullable;
 
 import com.getkeepsafe.cashier.logging.Logger;
 
@@ -203,7 +204,12 @@ public class Cashier {
         }
 
         final String payload = developerPayload == null ? "" : developerPayload;
-        vendor.purchase(activity, product, payload, purchaseListenerWrapper);
+
+        try {
+          vendor.purchase(activity, product, payload, purchaseListenerWrapper);
+        } catch (Exception e) {
+          purchaseListenerWrapper.failure(product, new Vendor.Error(VendorConstants.PURCHASE_FAILURE, -1));
+        }
       }
 
       @Override
@@ -232,7 +238,11 @@ public class Cashier {
           listener.failure(purchase, new Vendor.Error(VendorConstants.CONSUME_UNAVAILABLE, -1));
           return;
         }
-        vendor.consume(context, purchase, listener);
+        try {
+          vendor.consume(context, purchase, listener);
+        } catch (Exception e) {
+          listener.failure(purchase, new Vendor.Error(VendorConstants.CONSUME_UNAVAILABLE, -1));
+        }
       }
 
       @Override
@@ -265,7 +275,11 @@ public class Cashier {
     vendor.initialize(context, new Vendor.InitializationListener() {
       @Override
       public void initialized() {
-        vendor.getInventory(context, itemSkus, subSkus, listener);
+        try {
+          vendor.getInventory(context, itemSkus, subSkus, listener);
+        } catch (Exception e) {
+          listener.failure(new Vendor.Error(VendorConstants.INVENTORY_QUERY_UNAVAILABLE, -1));
+        }
       }
 
       @Override
@@ -290,7 +304,11 @@ public class Cashier {
     vendor.initialize(context, new Vendor.InitializationListener() {
       @Override
       public void initialized() {
-        vendor.getProductDetails(context, sku, isSubscription, listener);
+        try {
+          vendor.getProductDetails(context, sku, isSubscription, listener);
+        } catch (Exception e) {
+          listener.failure(new Vendor.Error(VendorConstants.PRODUCT_DETAILS_UNAVAILABLE, -1));
+        }
       }
 
       @Override

--- a/cashier/src/main/java/com/getkeepsafe/cashier/VendorMissingException.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/VendorMissingException.java
@@ -16,7 +16,8 @@
 
 package com.getkeepsafe.cashier;
 
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 public class VendorMissingException extends RuntimeException {
   public final String vendorId;

--- a/cashier/src/main/java/com/getkeepsafe/cashier/VendorMissingException.java
+++ b/cashier/src/main/java/com/getkeepsafe/cashier/VendorMissingException.java
@@ -13,9 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package com.getkeepsafe.cashier;
-
 
 import androidx.annotation.Nullable;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,22 +3,29 @@ ext {
             compileSdk : 28,
             minSdk     : 9,
             buildTools : '28.0.3',
-            versionName: '0.3.6'
+            versionName: '0.3.6',
+            autoValue  : '1.3',
+            autoParcel : '0.2.5',
+            appCompat  : '1.1.0',
+            support    : '1.1.0',
+            billing    : '1.2',
+            roboelectric: '3.3.2',
+            junit      : '4.12',
+            mockito    : '2.2.9',
+            truth      : '0.31'
     ]
 
-    final supportLibraryVersion = '1.0.2'
-
     deps = [
-            autoValue         : 'com.google.auto.value:auto-value:1.3',
-            autoParcel        : 'com.ryanharter.auto.value:auto-value-parcel:0.2.5',
-            appCompat         : "androidx.appcompat:appcompat:$supportLibraryVersion",
-            supportAnnotations: "androidx.annotation:annotation:$supportLibraryVersion",
-            billingClient     : 'com.android.billingclient:billing:1.2',
+            autoValue         : "com.google.auto.value:auto-value:${versions.autoValue}",
+            autoParcel        : "com.ryanharter.auto.value:auto-value-parcel:${versions.autoParcel}",
+            appCompat         : "androidx.appcompat:appcompat:${versions.appCompat}",
+            supportAnnotations: "androidx.annotation:annotation:${versions.support}",
+            billingClient     : "com.android.billingclient:billing:${versions.billing}",
 
             // Test dependencies
-            robolectric       : 'org.robolectric:robolectric:3.3.2',
-            junit             : 'junit:junit:4.12',
-            mockito           : 'org.mockito:mockito-core:2.2.9',
-            truth             : 'com.google.truth:truth:0.31'
+            robolectric       : "org.robolectric:robolectric:${versions.roboelectric}",
+            junit             : "junit:junit:${versions.junit}",
+            mockito           : "org.mockito:mockito-core:${versions.mockito}",
+            truth             : "com.google.truth:truth:${versions.truth}"
     ]
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,13 +6,13 @@ ext {
             versionName: '0.3.6'
     ]
 
-    final supportLibraryVersion = '28.0.0'
+    final supportLibraryVersion = '1.0.2'
 
     deps = [
             autoValue         : 'com.google.auto.value:auto-value:1.3',
             autoParcel        : 'com.ryanharter.auto.value:auto-value-parcel:0.2.5',
-            appCompat         : "com.android.support:appcompat-v7:$supportLibraryVersion",
-            supportAnnotations: "com.android.support:support-annotations:$supportLibraryVersion",
+            appCompat         : "androidx.appcompat:appcompat:$supportLibraryVersion",
+            supportAnnotations: "androidx.annotation:annotation:$supportLibraryVersion",
             billingClient     : 'com.android.billingclient:billing:1.2',
 
             // Test dependencies

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext {
             compileSdk : 28,
             minSdk     : 9,
             buildTools : '28.0.3',
-            versionName: '0.3.5'
+            versionName: '0.3.6'
     ]
 
     final supportLibraryVersion = '28.0.0'


### PR DESCRIPTION
Changes:
- Wrapped all vendor operations in try/catch to prevent carshing the client and report error using proper listener
- Covered a case of failing sku details query before launching billing flow
- Covered a case of app billing flow throwing exception. It caused a state if `pendingProduct` not being cleared, which in turn caused a not-recoverable state of next purchase calls throwing exception due to `pendingProduct != null`